### PR TITLE
adding graphene functional-tests to kitchensink-deltaspike

### DIFF
--- a/kitchensink-deltaspike/README.md
+++ b/kitchensink-deltaspike/README.md
@@ -101,6 +101,29 @@ _NOTE: If you use the Maven settings command line argument with this quickstart,
 
     mvn clean test -Parq-jbossas-remote -s /path/to/custom/settings.xml -Dorg.apache.maven.user-settings=/path/to/custom/settings.xml
 
+
+Run the Arquillian Functional Tests
+-----------------------------------
+
+This quickstart provides Arquillian functional tests as well. They are located under the directory "functional-tests". Functional tests verify that your application behaves correctly from the user's point of view - simulating clicking around the page as a normal user would do.
+
+To run these tests, you must build the main project as described above.
+
+1. Open a command line and navigate to the root directory of this quickstart.
+2. Build the quickstart WAR using the following command:
+
+        mvn clean package
+
+3. Navigate to the functional-tests/ directory in this quickstart.
+4. If you have a running instance of the JBoss Server, as described above, run the remote tests by typing the following command:
+
+        mvn clean verify -Parq-jbossas-remote
+
+5. If you prefer to run the functional tests using managed instance of the JBoss server, meaning the tests will start the server for you, type fhe following command:
+
+        mvn clean verify -Parq-jbossas-managed
+
+
 Run the Quickstart in JBoss Developer Studio or Eclipse
 -------------------------------------
 You can also start the server and deploy the quickstarts from Eclipse using JBoss tools. For more information, see [Use JBoss Developer Studio or Eclipse to Run the Quickstarts](../README.md#use-jboss-developer-studio-or-eclipse-to-run-the-quickstarts) 

--- a/kitchensink-deltaspike/functional-tests/pom.xml
+++ b/kitchensink-deltaspike/functional-tests/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.jboss.as.quickstarts.wfk</groupId>
+    <artifactId>jboss-kitchensink-deltaspike-test-webdriver</artifactId>
+    <version>2.4.0-redhat-SNAPSHOT</version>
+    <name>JBoss AS Quickstarts: Kitchensink test via WebDriver with Arquillian</name>
+    <description>This project tests a starter Java EE 6 webapp project for use on JBoss AS 7 / EAP 6 by WebDriver</description>
+
+    <url>http://jboss.org/jbossas</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <distribution>repo</distribution>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+        </license>
+    </licenses>
+
+    <properties>
+        <!-- Explicitly declaring the source encoding eliminates the following 
+                                 message: -->
+        <!-- [WARNING] Using platform encoding (UTF-8 actually) to copy filtered 
+                         resources, i.e. build is platform dependent! -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- JBoss dependency versions -->
+        <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
+
+        <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
+        <version.jboss.bom.wfk>2.4.0-build-SNAPSHOT</version.jboss.bom.wfk>
+
+        <version.jboss.bom.eap>6.2.0-redhat-1</version.jboss.bom.eap>
+
+        <!-- other plugin versions -->
+        <version.surefire.plugin>2.10</version.surefire.plugin>
+
+        <!-- maven-compiler-plugin -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.surefire.plugin}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Arquillian dependency -->
+            <dependency>
+                <groupId>org.jboss.bom.wfk</groupId>
+                <artifactId>jboss-javaee-6.0-with-tools</artifactId>
+                <version>${version.jboss.bom.wfk}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.graphene</groupId>
+            <artifactId>graphene-webdriver</artifactId>
+            <scope>test</scope>
+            <type>pom</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <!-- Profile that executes tests in managed JBoss AS instance. -->
+            <id>arq-jbossas-managed</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-arquillian-container-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <!-- Profile that executes tests in remote JBoss AS instance. -->
+            <id>arq-jbossas-remote</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>jboss-as-arquillian-container-remote</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
+</project>

--- a/kitchensink-deltaspike/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/webdriver/KitchensinkTest.java
+++ b/kitchensink-deltaspike/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/webdriver/KitchensinkTest.java
@@ -1,0 +1,358 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.quickstarts.kitchensink.test.webdriver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URL;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.Graphene;
+import org.jboss.arquillian.graphene.condition.element.WebElementConditionFactory;
+import org.jboss.arquillian.graphene.findby.ByJQuery;
+import org.jboss.arquillian.graphene.findby.FindByJQuery;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * This class provides Arquillian-related infrastructure and functional tests afterwards.
+ *
+ * @author <a href="mailto:smikloso@redhat.com">Stefan Miklosovic</a>
+ *
+ */
+@RunWith(Arquillian.class)
+public class KitchensinkTest {
+
+    /**
+     * Injects URL on which application is running.
+     */
+    @ArquillianResource
+    protected URL contextPath;
+
+    /**
+     * Injects browser to our test.
+     */
+    @Drone
+    protected WebDriver browser;
+
+    /**
+     * Specifies relative path to the war of built application in the main project.
+     */
+    private static final String DEPLOYMENT_WAR = "../target/jboss-kitchensink-deltaspike.war";
+
+    /**
+     * Creates deployment which is sent to the container upon test's start.
+     *
+     * @return war file which is deployed while testing, the whole application in our case
+     */
+    @Deployment(testable = false)
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.createFromZipFile(WebArchive.class, new File(DEPLOYMENT_WAR));
+    }
+
+    /**
+     * Locator for registration form
+     */
+    @FindBy(id = "reg")
+    private WebElement REGISTRATION_FORM;
+
+    /**
+     * Locator for the input field for entering of a name of the member we want to register.
+     */
+    @FindBy(id = "reg:name")
+    private WebElement NAME_FIELD;
+
+    /**
+     * Locator for the input field for entering of an e-mail of the new member we want to register.
+     */
+    @FindBy(id = "reg:email")
+    private WebElement EMAIL_FIELD;
+
+    /**
+     * Locator for the input field for entering of a telephone number of the new member we want to register.
+     */
+    @FindBy(id = "reg:phoneNumber")
+    private WebElement PHONE_FIELD;
+
+    /**
+     * This class variable holds locator for the registration button we click on while registering a new member.
+     */
+    @FindBy(id = "reg:register")
+    private WebElement REGISTER_BUTTON;
+
+    @FindByJQuery(".invalid")
+    private List<WebElement> INVALID;
+
+    /**
+     * This holds the locator for the table where member after registration appears.
+     */
+    @FindBy(css = ".simpletablestyle")
+    private WebElement TABLE_MEMBERS;
+
+    /**
+     * This holds the locator for the registration string after ("Registered!") after clicking on the register button.
+     */
+    @FindByJQuery(".valid")
+    private WebElement REGISTERED_MESSAGE;
+
+    /**
+     * Name of the member to register in the right format.
+     */
+    private final String NAME_FORMAT_OK = "John Doe";
+
+    /**
+     * Name of the member to register in the bad format.
+     */
+    private final String NAME_FORMAT_BAD = "123";
+
+    /**
+     * Name of the member to register which is too long (1-25)
+     */
+    private final String NAME_FORMAT_TOO_LONG = "John Doe John Doe John Doe";
+
+    /**
+     * E-mail of the member to register in the right format.
+     */
+    private final String EMAIL_FORMAT_OK = "john@doe.com";
+
+    /**
+     * E-mail of the member to register in the bad format - #1.
+     */
+    private final String EMAIL_FORMAT_BAD_1 = "joe";
+
+    /**
+     * E-mail of the member to register in the bad format - #2.
+     */
+    private final String EMAIL_FORMAT_BAD_2 = "john@doe.com ";
+
+    /**
+     * Phone number of the member to register in the right format.
+     */
+    private final String PHONE_FORMAT_OK = "0123456789";
+
+    /**
+     * Phone number of the member to register in the bad format.
+     */
+    private final String PHONE_FORMAT_BAD = "as/df.123@12";
+
+    /**
+     * Phone number of the member to register which is too small.
+     */
+    private final String PHONE_FORMAT_TOO_SMALL = "1";
+
+    /**
+     * Phone number of the member to register which is too long.
+     */
+    private final String PHONE_FORMAT_TOO_LONG = "1234567890123";
+
+    @Test
+    @InSequence(1)
+    public void testEmptyRegistration() {
+        open();
+
+        assertTrue("Registration form is not present on the page", REGISTRATION_FORM.isDisplayed());
+
+        Graphene.guardHttp(REGISTRATION_FORM).submit();
+
+        assertTrue(contains(INVALID, "size must be between 1 and 25"));
+        assertTrue(contains(INVALID, "may not be empty"));
+        assertTrue(contains(INVALID, "numeric value out of bounds (<12 digits>.<0 digits> expected)") ||
+                   contains(INVALID, "size must be between 10 and 12"));
+
+        assertTrue(!condition(REGISTERED_MESSAGE).isPresent().apply(browser));
+    }
+
+    @Test
+    @InSequence(2)
+    public void testRegistrationWithBadNameFormat() throws InterruptedException {
+        open();
+
+        setInputFields(NAME_FORMAT_BAD, EMAIL_FORMAT_OK, PHONE_FORMAT_OK);
+
+        Graphene.guardHttp(REGISTER_BUTTON).click();
+
+        assertTrue("Registration with bad name '" + NAME_FORMAT_BAD + "' succeeded",
+            contains(INVALID, "Must not contain numbers"));
+    }
+
+    @Test
+    @InSequence(3)
+    public void testRegistrationWithTooLongName() {
+        open();
+
+        setInputFields(NAME_FORMAT_TOO_LONG, EMAIL_FORMAT_OK, PHONE_FORMAT_OK);
+
+        Graphene.guardHttp(REGISTER_BUTTON).click();
+
+        assertTrue("Registration with bad name '" + NAME_FORMAT_TOO_LONG + "' succeeded",
+            contains(INVALID, "size must be between 1 and 25"));
+    }
+
+    @Test
+    @InSequence(4)
+    public void testRegistrationWithBadEmailFormat() {
+        open();
+
+        setInputFields(NAME_FORMAT_OK, EMAIL_FORMAT_BAD_1, PHONE_FORMAT_OK);
+
+        Graphene.guardHttp(REGISTRATION_FORM).submit();
+
+        assertTrue(contains(INVALID, "not a well-formed email address"));
+    }
+
+    @Test
+    @InSequence(5)
+    public void testRegistrationWithBadEmailFormat2() {
+        open();
+        setInputFields(NAME_FORMAT_OK, EMAIL_FORMAT_BAD_2, PHONE_FORMAT_OK);
+        Graphene.guardHttp(REGISTRATION_FORM).submit();
+        assertTrue(contains(INVALID, "not a well-formed email address"));
+    }
+
+    @Test
+    @InSequence(6)
+    public void testRegistrationWithTooSmallPhoneNumber() {
+        open();
+
+        setInputFields(NAME_FORMAT_OK, EMAIL_FORMAT_OK, PHONE_FORMAT_TOO_SMALL);
+
+        Graphene.guardHttp(REGISTRATION_FORM).submit();
+
+        assertTrue(contains(INVALID, "size must be between 10 and 12"));
+    }
+
+    @Test
+    @InSequence(7)
+    public void testRegistrationWithTooLongPhoneNumber() {
+        open();
+
+        setInputFields(NAME_FORMAT_OK, EMAIL_FORMAT_OK, PHONE_FORMAT_TOO_LONG);
+
+        Graphene.guardHttp(REGISTRATION_FORM).submit();
+
+        // Both validators make sense here
+        assertTrue(contains(INVALID, "numeric value out of bounds (<12 digits>.<0 digits> expected)") || 
+                   contains(INVALID, "size must be between 10 and 12"));
+    }
+
+    @Test
+    @InSequence(8)
+    public void testRegistrationWithBadPhoneNumber() {
+        open();
+
+        setInputFields(NAME_FORMAT_OK, EMAIL_FORMAT_OK, PHONE_FORMAT_BAD);
+
+        Graphene.guardHttp(REGISTRATION_FORM).submit();
+
+        assertTrue(contains(INVALID, "numeric value out of bounds (<12 digits>.<0 digits> expected)"));
+    }
+
+    @Test
+    @InSequence(9)
+    public void testRegularRegistration() {
+        open();
+        setInputFields(NAME_FORMAT_OK, EMAIL_FORMAT_OK, PHONE_FORMAT_OK);
+
+        Graphene.guardHttp(REGISTER_BUTTON).click();
+
+        assertTrue(condition(REGISTERED_MESSAGE).isVisible().apply(browser));
+
+        // extract table body from the member table
+        WebElement rows = TABLE_MEMBERS.findElement(ByJQuery.selector("tbody"));
+
+        // extract rows of the table body
+        List<WebElement> members = rows.findElements(ByJQuery.selector("tr"));
+
+        // assert we got 2 rows
+        assertEquals(2, members.size());
+
+        // get columns of the registered user
+        List<WebElement> columns = members.get(0).findElements(ByJQuery.selector("td"));
+
+        // assert we got 5 of them
+        assertEquals(5, columns.size());
+
+        // checks if we stored what we entered.
+        assertTrue(columns.get(0).getText().equals("1"));
+        assertTrue(columns.get(1).getText().equals(NAME_FORMAT_OK));
+        assertTrue(columns.get(2).getText().equals(EMAIL_FORMAT_OK));
+        assertTrue(columns.get(3).getText().equals(PHONE_FORMAT_OK));
+    }
+
+    /**
+     * Helper method which opens the main page for us.
+     */
+    public void open() {
+        browser.get(contextPath.toString());
+        Graphene.waitModel(browser).until().element(REGISTRATION_FORM).is().visible();
+    }
+
+    /**
+     * This helper method sets values into the according input fields.
+     *
+     * @param name name to set into the name input field
+     * @param email email to set into the email input field
+     * @param phone phone to set into the phone input field
+     */
+    private void setInputFields(String name, String email, String phone) {
+        NAME_FIELD.clear();
+        NAME_FIELD.sendKeys(name);
+
+        EMAIL_FIELD.clear();
+        EMAIL_FIELD.sendKeys(email);
+
+        PHONE_FIELD.clear();
+        PHONE_FIELD.sendKeys(phone);
+    }
+
+    /**
+     * Helper method which checks if some list of WebElemets contains an element which holds some particular message.
+     *
+     * @param elements list of elements to check the existence of a message of
+     * @param message
+     * @return true if list of elemets contains the message, false otherwise
+     */
+    private boolean contains(final List<WebElement> elements, String message) {
+        for (WebElement element : elements) {
+            if (element.getText().equals(message)) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
+    /**
+     * Helper method to create conditions on WebElements
+     * @param element
+     * @return
+     */
+    private WebElementConditionFactory condition(WebElement element) {
+       return new WebElementConditionFactory(element);
+    }
+}

--- a/kitchensink-deltaspike/functional-tests/src/test/resources/arquillian.xml
+++ b/kitchensink-deltaspike/functional-tests/src/test/resources/arquillian.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <!-- Example configuration for a remote JBoss Enterprise Application Platform 6 or AS 7 instance -->
+    <container qualifier="jboss" default="true">
+        <!-- By default, Arquillian will use the JBOSS_HOME environment variable. 
+            Alternatively, the configuration below can be uncommented. -->
+        <!--
+        <configuration>
+            <property name="jbossHome">/path/to/jboss/as</property>
+        </configuration>
+        -->
+    </container>
+
+    <!-- WebDriver extension -->
+    <extension qualifier="webdriver">
+        <!-- By default, the browser you are going to use for your tests is set to Firefox. -->
+        <property name="browser">firefox</property>
+        <!-- Uncomment this line in order to specify where your Firefox binary is located, WebDriver 
+            will use the default one in your system otherwise. These tests are verified to be functioning 
+            with Firefox 23. -->
+        <!--
+        <property name="firefox_binary">/path/to/firefox/binary</property>
+        -->
+    </extension>
+
+</arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,18 @@
                 <module>jts-distributed-crash-rec</module>
             </modules>
         </profile>
+        <profile>
+            <!-- Functional tests are not part of the quickstarts' structure.
+                Follow the quickstart README files to run the individual 
+                functional tests. -->
+            <id>functional-tests</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>kitchensink-deltaspike/functional-tests</module>
+            </modules>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
Adding the first functional test as a template for the other quickstarts' functional tests.

This commit depends on the Drone/Graphene upgrade in the WFK BOM (https://github.com/jboss-developer/jboss-wfk-boms/pull/3 )
