### PR TITLE
README change: corrected the "Run the Arquillian Tests" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,39 +267,44 @@ To undeploy any quickstarts that fail due to complex dependencies, follow the un
 ### Run the Arquillian Tests
 ----------------------------
 
-Some of the quickstarts provide Arquillian tests. By default, these tests are configured to be skipped, as Arquillian tests require the use of a container. 
+Some of the quickstarts provide Arquillian tests. By default, these tests are configured to be skipped, as Arquillian tests an application on a real server, not just in a mocked environment.
 
-You can run these tests using either a remote or managed container. The quickstart README should tell you what you should expect to see in the console output and server log when you run the test.
+You can either start the server yourself or let Arquillian manage its lifecycle during the testing. The individual quickstart README should tell you what to expect in the console output and the server log when you run the test.
 
 
-1. Test the quickstart on a Remote Server
-    * A remote container requires you start the JBoss EAP server before running the test. [Start the JBoss server](#start-the-jboss-server) as described in the quickstart README file.
+1. Test the quickstart on a remote server
+    * Arquillian's remote container adapter expects a JBoss server instance to be already started prior to the test execution. You might want to [Start the JBoss server](#start-the-jboss-server) as described in the quickstart README file.
+    * If you need to run the tests on a JBoss server running on a machine other than localhost, you can configure this, along with other options, in the `src/test/resources/arquillian.xml` file using the following properties:
+        
+            <container qualifier="jboss" default="true">
+                <configuration>
+                    <property name="managementAddress">myhost.example.com</property>
+                    <property name="managementPort">9999</property>
+                    <property name="username">customAdminUser</property>
+                    <property name="password">myPassword</property>
+                </configuration>
+            </container>
+    
     * Run the test goal with the following profile activated:
 
             mvn clean test -Parq-jbossas-remote 
-2. Test the quickstart on Managed Server
 
-    _Note: This test requires that your server is not running. Arquillian will start the container for you, however, you must first let it know where to find the remote JBoss container._
-    * Open the test/resources/arquillian.xml file located in the quickstart directory. 
-    * Find the configuration for the remote JBoss container. It should look like this:
+    
+2. Test the quickstart on a managed server
 
-            <!-- Example configuration for a remote JBoss EAP instance -->
+    Arquillian's managed container adapter requires that your server is not running as it will start the container for you. However, you must first let it know where to find the JBoss server directory. The simplest way to do this is to set the `JBOSS_HOME` environment variable to the full path to your JBoss server directory. Alternatively, you can set the path in the `jbossHome` property in the Arquillian configuration file.
+    * Open the `src/test/resources/arquillian.xml` file located in the quickstart directory.
+    * Find the configuration for the JBoss container. It should look like this:
+
+            <!-- Example configuration for a managed/remote JBoss AS 7 instance -->
             <container qualifier="jboss" default="true">
-                <!-- By default, arquillian will use the JBOSS_HOME environment variable.  Alternatively, the configuration below can be uncommented. -->
+                <!-- If you want to use the JBOSS_HOME environment variable, just delete the jbossHome property -->
                 <!--<configuration> -->
                 <!--<property name="jbossHome">/path/to/jboss/as</property> -->
                 <!--</configuration> -->
             </container>
-    * Remove the comments from the `<configuration>` elements.
-
-            <!-- Example configuration for a remote JBoss EAP instance -->
-            <container qualifier="jboss" default="true">
-                <!-- By default, arquillian will use the JBOSS_HOME environment variable.  Alternatively, the configuration below can be uncommented. -->
-                <configuration>
-                    <property name="jbossHome">/path/to/jboss/as</property>
-                </configuration>
-            </container>
-    * Find the "jbossHome" property and replace the "/path/to/jboss/as" value with the actual path to your JBoss EAP server.
+            
+    * Uncomment the `configuration` element, find the `jbossHome` property and replace the "/path/to/jboss/as" value with the actual path to your JBoss EAP server.
     * Run the test goal with the following profile activated:
 
             mvn clean test -Parq-jbossas-managed
@@ -668,5 +673,4 @@ When instructed to use Byteman to halt the application, perform the following st
 #### Disable the Byteman Script
  
 When you are done testing the quickstart, remember to restore the configuration file with the backup copy you made in step 2 above.
-
 


### PR DESCRIPTION
- emphasized the importance of Arquillian
- corrected and minimised the usage of the word "container" throughout the section, as it can be ambiguous
- described configuration options of arq remote container and emphasize that it can actually be used to run tests on different machines
- corrected usage of "test/resources/arquillian.xml" to "src/test/resources/arquillian.xml"
- the "managed container" section incorrectly contained mentions of a remote container
- mentioned the possibility to use JBOSS_HOME env var
- I found the managed container section too verbose, I think there's no need for two code snippets, one is plenty
