### PR TITLE
JDF-526 Fixed Arquillian test failure.

### DIFF
--- a/kitchensink-backbone/src/test/java/org/jboss/as/quickstarts/kitchensink/test/MemberRegistrationTest.java
+++ b/kitchensink-backbone/src/test/java/org/jboss/as/quickstarts/kitchensink/test/MemberRegistrationTest.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.Response;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -67,8 +68,9 @@ public class MemberRegistrationTest {
     Logger log;
 
     @Test
+    @InSequence(1)
     public void testRegister() throws Exception {
-        Member member = createMemberInstance("Jane Doe", "jane@mailinator.com",
+        Member member = createMemberInstance("Jack Doe", "jack@mailinator.com",
                 "2125551234");
         Response response = memberRegistration.createMember(member);
 
@@ -79,6 +81,7 @@ public class MemberRegistrationTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    @InSequence(2)
     public void testInvalidRegister() throws Exception {
         Member member = createMemberInstance("", "", "");
         Response response = memberRegistration.createMember(member);
@@ -96,6 +99,7 @@ public class MemberRegistrationTest {
 
     @SuppressWarnings("unchecked")
     @Test
+    @InSequence(3)
     public void testDuplicateEmail() throws Exception {
         // Register an initial user
         Member member = createMemberInstance("Jane Doe", "jane@mailinator.com",


### PR DESCRIPTION
Used @InSequence annotatiosn in combination with a separate member to ensure that the duplicate test succeeds.
