### PR TITLE
Fix JDF-558. Update the WHERE clause so that it will Filter.

### DIFF
--- a/kitchensink-spring-matrixvariables/src/main/resources/META-INF/persistence.xml
+++ b/kitchensink-spring-matrixvariables/src/main/resources/META-INF/persistence.xml
@@ -31,6 +31,7 @@
             <!-- Properties for Hibernate -->
             <property name="hibernate.hbm2ddl.auto" value="create-drop" />
             <property name="hibernate.show_sql" value="false" />
+            <property name="hibernate.format_sql" value="false" />
         </properties>
     </persistence-unit>
 </persistence>


### PR DESCRIPTION
Fix JDF-558. Update the WHERE clause so that the Filter in kitchensink-spring-matrixvariables would handle an AND condition. One WHERE clause was overwriting the other.

If you want to observe this turn on the "show-sql" and "format_sql" in the persistence.xml.
