### PR TITLE
JDF-613 Set up integration test in their own profile 

### DIFF
--- a/spring-resteasy/README.md
+++ b/spring-resteasy/README.md
@@ -43,7 +43,9 @@ Start the JBoss Server
 Build and Deploy the Quickstart
 -------------------------------
 
-_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#build-and-deploy-the-quickstarts) for complete instructions and additional options._
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include 
+Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#build-and-deploy-the-quickstarts) 
+for complete instructions and additional options._
 
 1. Make sure you have started the JBoss Server as described above.
 2. Open a command line and navigate to the root directory of this quickstart.
@@ -54,12 +56,22 @@ _NOTE: The following build command assumes you have configured your Maven user s
 4. This deploys the `target/jboss-spring-resteasy.war` to the running instance of the server.
 
 
-4. This deploys the `target/jboss-spring-resteasy.war` to the running instance of the server and runs two integration tests that verify the application works. You should see the following output:
-   
-   _Note:_ If you prefer to use the `mvn install` command to run the integration tests, you must deploy the application first. For example:
+Build, Deploy, and Test the Quickstart
+-------------------------------
+
+_NOTE: The following build command assumes you have configured your Maven user settings. If you have not, you must include 
+Maven setting arguments on the command line. See [Build and Deploy the Quickstarts](../README.md#build-and-deploy-the-quickstarts) 
+for complete instructions and additional options._
+
+1. Make sure you have started the JBoss Server as described above.
+2. Open a command line and navigate to the root directory of this quickstart.
+3. Type these commands to build, deploy, and test the archive:
 
         mvn clean package jboss-as:deploy
         mvn install -Prest-test
+
+4. This deploys the `target/jboss-spring-resteasy.war` to the running instance of the server and runs two integration tests that verify the application works. You should see the following output:
+   
 
         -------------------------------------------------------
          T E S T S

--- a/spring-resteasy/README.md
+++ b/spring-resteasy/README.md
@@ -14,6 +14,8 @@ What is it?
 This project demonstrates how to package and deploy a web application, which includes resteasy-spring integration, into 
 Red Hat JBoss Enterprise Application Platform.
 
+Currently the resteasy-spring.jar is using Spring 3.0.3, as such this quickstart needs to run on some version of Spring 3.x.
+
 
 System requirements
 -------------------
@@ -47,9 +49,18 @@ _NOTE: The following build command assumes you have configured your Maven user s
 2. Open a command line and navigate to the root directory of this quickstart.
 3. Type this command to build and deploy the archive:
 
-        mvn clean package jboss-as:deploy integration-test
+        mvn clean package jboss-as:deploy
+        
+4. This deploys the `target/jboss-spring-resteasy.war` to the running instance of the server.
+
+
 4. This deploys the `target/jboss-spring-resteasy.war` to the running instance of the server and runs two integration tests that verify the application works. You should see the following output:
    
+   _Note:_ If you prefer to use the `mvn install` command to run the integration tests, you must deploy the application first. For example:
+
+        mvn clean package jboss-as:deploy
+        mvn install -Prest-test
+
         -------------------------------------------------------
          T E S T S
         -------------------------------------------------------
@@ -64,10 +75,6 @@ _NOTE: The following build command assumes you have configured your Maven user s
         [INFO] BUILD SUCCESS
         [INFO] ------------------------------------------------------------------------
 
-   _Note:_ If you prefer to use the `mvn install` command to run the integration tests, you must deploy the application first. For example:
-
-        mvn clean package jboss-as:deploy
-        mvn install
 
 Access the application 
 ---------------------

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -59,12 +59,12 @@
         <version.commons.logging>1.1.1</version.commons.logging>
 
         <!-- RESTEasy Version -->
-<!--         <version.springframework>3.2.4.RELEASE</version.springframework> -->
+        <version.springframework>3.2.7.RELEASE</version.springframework>
 
         <!-- Maven Plugin Versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
         <version.surefire.plugin>2.10</version.surefire.plugin>
-<!--         <version.war.plugin>2.1.1</version.war.plugin> -->
+        <version.war.plugin>2.1.1</version.war.plugin>
 
         <!-- maven-compiler-plugin settings -->
         <maven.compiler.source>1.6</maven.compiler.source>
@@ -99,6 +99,19 @@
                 <artifactId>commons-logging</artifactId>
                 <version>${version.commons.logging}</version>
             </dependency>
+	        
+	        <!-- Spring -->
+<!-- 	        <dependency> -->
+<!-- 	            <groupId>org.springframework</groupId> -->
+<!-- 	            <artifactId>spring-context</artifactId> -->
+<!-- 	            <version>${version.springframework}</version> -->
+<!-- 	        </dependency> -->
+<!-- 	        <dependency> -->
+<!-- 	            <groupId>org.springframework</groupId> -->
+<!-- 	            <artifactId>spring-web</artifactId> -->
+<!-- 	            <version>${version.springframework}</version> -->
+<!-- 	        </dependency> -->
+	        
         </dependencies>
     </dependencyManagement>
 
@@ -150,45 +163,99 @@
             <version>${version.org.apache.httpcomponents}</version>
             <scope>test</scope>
         </dependency>
+        
+        <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
+            <version>${version.springframework}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
+            <version>${version.springframework}</version>
         </dependency>
+        
+        <!-- Bring in the Servlet jars to avoid errors while compiling with jdt. -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
+            <artifactId>jboss-jsp-api_2.2_spec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
+            <artifactId>jboss-jstl-api_1.2_spec</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>
+        <!-- Maven will append the version to the finalName (which is the name given to the generated war, and hence the context 
+            root) -->
         <finalName>${project.artifactId}</finalName>
         <plugins>
-            <!-- JBoss AS plugin to deploy war -->
+            <!-- The JBoss AS plugin deploys your war to a local JBoss AS container -->
+            <!-- To use, run: mvn package jboss-as:deploy -->
             <plugin>
                 <groupId>org.jboss.as.plugins</groupId>
                 <artifactId>jboss-as-maven-plugin</artifactId>
                 <version>${version.jboss.maven.plugin}</version>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.surefire.plugin}</version>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>surefire-it</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <skip>false</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <!-- The default profile skips all tests, though you can tune it to run just unit tests based on a custom pattern -->
+            <!-- Separate profiles are provided for running all tests, including Arquillian tests that execute in the specified container -->
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+		            <plugin>
+		                <groupId>org.apache.maven.plugins</groupId>
+		                <artifactId>maven-surefire-plugin</artifactId>
+		                <version>${version.surefire.plugin}</version>
+		                <configuration>
+		                    <skip>true</skip>
+		                </configuration>
+		            </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <!-- The default profile skips all tests, though you can tune it to run just unit tests based on a custom pattern -->
+            <!-- Seperate profiles are provided for running all tests, including Arquillian tests that execute in the specified container -->
+            <id>rest-test</id>
+            <build>
+                <plugins>
+		            <plugin>
+		                <groupId>org.apache.maven.plugins</groupId>
+		                <artifactId>maven-surefire-plugin</artifactId>
+		                <version>${version.surefire.plugin}</version>
+<!-- 		                <configuration> -->
+<!-- 		                    <skip>true</skip> -->
+<!-- 		                </configuration> -->
+		                <executions>
+		                    <execution>
+		                        <id>surefire-it</id>
+		                        <phase>integration-test</phase>
+		                        <goals>
+		                            <goal>test</goal>
+		                        </goals>
+		                        <configuration>
+		                            <skip>false</skip>
+		                        </configuration>
+		                    </execution>
+		                </executions>
+		            </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Two things needed to happen here;

1) Needed to override the BOM version of Spring so that it uses Spring 3.2.7

2) Created a Profile in the pom for the Integration tests so that they didn't run all the time.

**The README still needs help/work**
