### PR TITLE
[WFK2-394, WFK2-434, JDF-630] Update spring-* quickstarts

### DIFF
--- a/spring-greeter/pom.xml
+++ b/spring-greeter/pom.xml
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <version.surefire.plugin>2.10</version.surefire.plugin>
@@ -85,7 +85,7 @@
 
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/spring-kitchensink-asyncrequestmapping/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/pom.xml
@@ -26,7 +26,7 @@
     <packaging>war</packaging>
     
     <name>JBoss WFK Quickstart: spring-kitchensink-asyncrequestmapping</name>
-    <description>Getting Started with Spring on JBoss with Spring 3.2 using AsyncRequests</description>
+    <description>Getting Started with Spring 4.0 on JBoss - AsyncRequests</description>
 
     <url>http://jboss.org/jbossas</url>
     <licenses>
@@ -48,7 +48,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -78,7 +78,7 @@
                 from the Hibernate family of projects) -->
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/spring-kitchensink-basic/pom.xml
+++ b/spring-kitchensink-basic/pom.xml
@@ -25,7 +25,7 @@
     <packaging>war</packaging>
 
     <name>JBoss WFK Quickstart: spring-kitchensink-basic</name>
-    <description>Getting Started with Spring on JBoss</description>
+    <description>Getting Started with Spring 4.0 on JBoss</description>
 
     <url>http://jboss.org/jbossas</url>
     <licenses>
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -77,7 +77,7 @@
                 from the Hibernate family of projects) -->
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/spring-kitchensink-controlleradvice/pom.xml
+++ b/spring-kitchensink-controlleradvice/pom.xml
@@ -26,7 +26,7 @@
     <packaging>war</packaging>
     
     <name>JBoss WFK Quickstart: spring-kitchensink-controlleradvice</name>
-    <description>Getting Started with Spring on JBoss with Spring 3.2 Controller Advice</description>
+    <description>Getting Started with Spring 4.0 on JBoss - Controller Advice</description>
 
     <url>http://jboss.org/jbossas</url>
     <licenses>
@@ -48,7 +48,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -78,7 +78,7 @@
                 from the Hibernate family of projects) -->
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/spring-kitchensink-matrixvariables/pom.xml
+++ b/spring-kitchensink-matrixvariables/pom.xml
@@ -26,7 +26,7 @@
     <packaging>war</packaging>
     
     <name>JBoss WFK Quickstart: spring-kitchensink-matrixvariables</name>
-    <description>Getting Started with Spring on JBoss with Spring 3.2 Matrix Variables</description>
+    <description>Getting Started with Spring 4.0 on JBoss - Matrix Variables</description>
 
     <url>http://jboss.org/jbossas</url>
     <licenses>
@@ -48,7 +48,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -78,7 +78,7 @@
                 from the Hibernate family of projects) -->
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/spring-kitchensink-springmvctest/pom.xml
+++ b/spring-kitchensink-springmvctest/pom.xml
@@ -26,7 +26,7 @@
     <packaging>war</packaging>
     
     <name>JBoss WFK Quickstart: spring-kitchensink-springmvctest</name>
-    <description>Getting Started with Spring on JBoss - with Spring 3.2 MVC Tests</description>
+    <description>Getting Started with Spring 4.0 on JBoss - MVC Tests</description>
 
     <url>http://jboss.org/jbossas</url>
     <licenses>
@@ -48,7 +48,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -82,7 +82,7 @@
                 from the Hibernate family of projects) -->
             <dependency>
                 <groupId>org.jboss.bom.wfk</groupId>
-                <artifactId>jboss-javaee-6.0-with-spring</artifactId>
+                <artifactId>jboss-javaee-6.0-with-spring4</artifactId>
                 <version>${version.jboss.bom.wfk}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/spring-petclinic/pom.xml
+++ b/spring-petclinic/pom.xml
@@ -39,7 +39,7 @@
 		<jboss.maven.plugin.version>7.4.Final</jboss.maven.plugin.version>
 
 		<!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-		<jboss.bom.wfk.version>2.5.0-build-2</jboss.bom.wfk.version>
+		<jboss.bom.wfk.version>2.5.0-build-3</jboss.bom.wfk.version>
 		<jboss.bom.eap.version>6.2.0.GA</jboss.bom.eap.version>
 
 		<!-- Generic properties -->
@@ -412,7 +412,7 @@
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.bom.wfk</groupId>
-				<artifactId>jboss-javaee-6.0-with-spring</artifactId>
+				<artifactId>jboss-javaee-6.0-with-spring4</artifactId>
 				<version>${jboss.bom.wfk.version}</version>
 				<type>pom</type>
 				<scope>import</scope>

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -51,7 +51,7 @@
         
 <!--         AT the moment this app does NOT work with Spring 4, so we are keeping it on Spring 3.2.x. I believe there is
              a bug in the Spring code.  Further testing is needed. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
 
         <!-- Other dependency versions -->
 <!--         <version.org.apache.httpcomponents>4.1.4</version.org.apache.httpcomponents> -->
@@ -59,7 +59,7 @@
         <version.commons.logging>1.1.1</version.commons.logging>
 
         <!-- RESTEasy Version -->
-        <version.springframework>3.2.7.RELEASE</version.springframework>
+<!--         <version.springframework>3.2.7.RELEASE</version.springframework> -->
 
         <!-- Maven Plugin Versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
@@ -168,12 +168,12 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>${version.springframework}</version>
+<!--             <version>${version.springframework}</version> -->
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>${version.springframework}</version>
+<!--             <version>${version.springframework}</version> -->
         </dependency>
         
         <!-- Bring in the Servlet jars to avoid errors while compiling with jdt. -->


### PR DESCRIPTION
Update the spring-\* quickstarts to use the spring4 BOM from WFK 2.5. 

Update pom description from Spring 3.2 to 4.0.

To test this please make sure you get the latest tag "2.5.0-build-3" from jboss-wfk-bom and "install" it.
