### PR TITLE
JDF-629 Fixed EJB container error on absent members.

### DIFF
--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/wfk/rest/MemberService.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/wfk/rest/MemberService.java
@@ -83,15 +83,15 @@ public class MemberService {
     @GET
     @Path("/{id:[0-9][0-9]*}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Member lookupMemberById(@PathParam("id") long id) {
+    public Response lookupMemberById(@PathParam("id") long id) {
         Member member = repository.findById(id);
         if (member == null) {
-            throw new WebApplicationException(Response.Status.NOT_FOUND);
+            return Response.status(Response.Status.NOT_FOUND).build();
         }
         log.info("findById " + id + ": found Member = " + member.getFirstName() + " " + member.getLastName() + " " + member.getEmail() + " " + member.getPhoneNumber() + " "
                 + member.getBirthDate() + " " + member.getId());
         
-        return member;
+        return Response.ok(member).build();
     }
 
     /**

--- a/kitchensink-backbone/src/main/java/org/jboss/as/quickstarts/kitchensink/rest/MemberService.java
+++ b/kitchensink-backbone/src/main/java/org/jboss/as/quickstarts/kitchensink/rest/MemberService.java
@@ -76,12 +76,12 @@ public class MemberService {
     @GET
     @Path("/{id:[0-9][0-9]*}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Member lookupMemberById(@PathParam("id") long id) {
+    public Response lookupMemberById(@PathParam("id") long id) {
         Member member = repository.findById(id);
         if (member == null) {
-            throw new WebApplicationException(Response.Status.NOT_FOUND);
+            return Response.status(Response.Status.NOT_FOUND).build();
         }
-        return member;
+        return Response.ok(member).build();
     }
 
     /**

--- a/kitchensink-html5-mobile/src/main/java/org/jboss/as/quickstarts/html5_mobile/rest/MemberService.java
+++ b/kitchensink-html5-mobile/src/main/java/org/jboss/as/quickstarts/html5_mobile/rest/MemberService.java
@@ -75,12 +75,12 @@ public class MemberService {
     @GET
     @Path("/{id:[0-9][0-9]*}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Member lookupMemberById(@PathParam("id") long id) {
+    public Response lookupMemberById(@PathParam("id") long id) {
         Member member = repository.findById(id);
         if (member == null) {
-            throw new WebApplicationException(Response.Status.NOT_FOUND);
+            return Response.status(Response.Status.NOT_FOUND).build();
         }
-        return member;
+        return Response.ok(member).build();
     }
 
     /**


### PR DESCRIPTION
The REST resource now returns a Response instead of a Member.

This ensures that a WebApplicationException is not the cause of an EJBException thrown by the EJB container.

Test this by deploying and pointing the browser to http://localhost:8080/jboss-kitchensink-html5-mobile/rest/members/1 and similar such URLs. http://localhost:8080/jboss-kitchensink-html5-mobile/rest/members/0 should return an existing member. Subsequent requests should not fail as reported in the bug.
