### PR TITLE
JDF-634 Added Statusbar plugin to configure statusbar on IOS7

### DIFF
--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/.npmignore
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/.npmignore
@@ -1,0 +1,23 @@
+﻿#If ignorance is bliss, then somebody knock the smile off my face
+
+*.csproj.user
+*.suo
+*.cache
+Thumbs.db
+*.DS_Store
+
+*.bak
+*.cache
+*.log
+*.swp
+*.user
+
+
+
+
+
+
+
+
+
+ 

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/LICENSE
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/README.md
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/README.md
@@ -1,0 +1,22 @@
+<!---
+ license: Licensed to the Apache Software Foundation (ASF) under one
+         or more contributor license agreements.  See the NOTICE file
+         distributed with this work for additional information
+         regarding copyright ownership.  The ASF licenses this file
+         to you under the Apache License, Version 2.0 (the
+         "License"); you may not use this file except in compliance
+         with the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+         Unless required by applicable law or agreed to in writing,
+         software distributed under the License is distributed on an
+         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+         KIND, either express or implied.  See the License for the
+         specific language governing permissions and limitations
+         under the License.
+-->
+
+# org.apache.cordova.device
+
+Plugin documentation: [doc/index.md](doc/index.md)

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/RELEASENOTES.md
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/RELEASENOTES.md
@@ -1,0 +1,57 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+-->
+# Release Notes
+
+### 0.2.1 (Sept 5, 2013)
+* removed extraneous print statement
+* [CB-4432] copyright notice change
+
+### 0.2.3 (Sept 25, 2013)
+* CB-4889 bumping&resetting version
+* [windows8] commandProxy has moved
+* [BlackBerry10] removed uneeded permission tags in plugin.xml
+* CB-4889 renaming org.apache.cordova.core.device to org.apache.cordova.device
+* Rename CHANGELOG.md -> RELEASENOTES.md
+* updated to use commandProxy for ffos
+* add firefoxos support
+* [CB-4752] Incremented plugin version on dev branch. 
+
+### 0.2.4 (Oct 28, 2013)
+* CB-5128: added repo + issue tag in plugin.xml for device plugin
+* CB-5085 device.cordova returning wrong value
+* [CB-4915] Incremented plugin version on dev branch.
+
+### 0.2.5 (Dec 4, 2013)
+* CB-5316 Spell Cordova as a brand unless it's a command or script
+* [ubuntu] use cordova/exec/proxy
+* add ubuntu platform
+* Modify Device.platform logic to use amazon-fireos as the platform for Amazon Devices
+* 1. Added amazon-fireos platform. 2. Change to use cordova-amazon-fireos as the platform if user agent contains 'cordova-amazon-fireos'
+
+### 0.2.6 (Jan 02, 2014)
+* CB-5658 Add doc/index.md for Device plugin
+* CB-5504 Moving Telephony Logic out of Device
+
+### 0.2.7 (Jan 07, 2014)
+* CB-5737 Fix exception on close caused by left over telephony code from CB-5504
+
+### 0.2.8 (Feb 05, 2014)
+* Tizen support added

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/doc/index.md
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/doc/index.md
@@ -1,0 +1,213 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# org.apache.cordova.device
+
+This plugin defines a global `device` object, which describes the device's hardware and software.
+Although the object is in the global scope, it is not available until after the `deviceready` event.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(device.cordova);
+    }
+
+## Installation
+
+    cordova plugin add org.apache.cordova.device
+
+## Properties
+
+- device.cordova
+- device.model
+- device.name
+- device.platform
+- device.uuid
+- device.version
+
+## device.cordova
+
+Get the version of Cordova running on the device.
+
+### Supported Platforms
+
+- Amazon Fire OS
+- Android
+- BlackBerry 10
+- Firefox OS
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+## device.model
+
+The `device.model` returns the name of the device's model or
+product. The value is set by the device manufacturer and may be
+different across versions of the same product.
+
+### Supported Platforms
+
+- Android
+- BlackBerry 10
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+### Quick Example
+
+    // Android:    Nexus One       returns "Passion" (Nexus One code name)
+    //             Motorola Droid  returns "voles"
+    // BlackBerry: Torch 9800      returns "9800"
+    // iOS:     for the iPad Mini, returns iPad2,5; iPhone 5 is iPhone 5,1. See http://theiphonewiki.com/wiki/index.php?title=Models
+    //
+    var model = device.model;
+
+### Android Quirks
+
+- Gets the [product name](http://developer.android.com/reference/android/os/Build.html#PRODUCT) instead of the [model name](http://developer.android.com/reference/android/os/Build.html#MODEL), which is often the production code name. For example, the Nexus One returns `Passion`, and Motorola Droid returns `voles`.
+
+### Tizen Quirks
+
+- Returns the device model assigned by the vendor, for example, `TIZEN`
+
+### Windows Phone 7 and 8 Quirks
+
+- Returns the device model specified by the manufacturer. For example, the Samsung Focus returns `SGH-i917`.
+
+## device.name
+
+__WARNING__: `device.name` is deprecated as of version 2.3.0. Use `device.model` instead.
+
+## device.platform
+
+Get the device's operating system name.
+
+    var string = device.platform;
+
+### Supported Platforms
+
+- Android
+- BlackBerry 10
+- Firefox OS
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+### Quick Example
+
+    // Depending on the device, a few examples are:
+    //   - "Android"
+    //   - "BlackBerry 10"
+    //   - "iOS"
+    //   - "WinCE"
+    //   - "Tizen"
+    var devicePlatform = device.platform;
+
+### Windows Phone 7 Quirks
+
+Windows Phone 7 devices report the platform as `WinCE`.
+
+### Windows Phone 8 Quirks
+
+Windows Phone 8 devices report the platform as `Win32NT`.
+
+## device.uuid
+
+Get the device's Universally Unique Identifier ([UUID](http://en.wikipedia.org/wiki/Universally_Unique_Identifier)).
+
+    var string = device.uuid;
+
+### Description
+
+The details of how a UUID is generated are determined by the device manufacturer and are specific to the device's platform or model.
+
+### Supported Platforms
+
+- Android
+- BlackBerry 10
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+### Quick Example
+
+    // Android: Returns a random 64-bit integer (as a string, again!)
+    //          The integer is generated on the device's first boot
+    //
+    // BlackBerry: Returns the PIN number of the device
+    //             This is a nine-digit unique integer (as a string, though!)
+    //
+    // iPhone: (Paraphrased from the UIDevice Class documentation)
+    //         Returns a string of hash values created from multiple hardware identifies.
+    //         It is guaranteed to be unique for every device and can't be tied
+    //         to the user account.
+    // Windows Phone 7 : Returns a hash of device+current user,
+    // if the user is not defined, a guid is generated and will persist until the app is uninstalled
+    // Tizen: returns the device IMEI (International Mobile Equipment Identity or IMEI is a number
+    // unique to every GSM and UMTS mobile phone.
+    var deviceID = device.uuid;
+
+### iOS Quirk
+
+The `uuid` on iOS is not unique to a device, but varies for each
+application, for each installation.  It changes if you delete and
+re-install the app, and possibly also when you upgrade iOS, or even
+upgrade the app per version (apparent in iOS 5.1). The `uuid` is not
+a reliable value.
+
+### Windows Phone 7 and 8 Quirks
+
+The `uuid` for Windows Phone 7 requires the permission
+`ID_CAP_IDENTITY_DEVICE`.  Microsoft will likely deprecate this
+property soon.  If the capability is not available, the application
+generates a persistent guid that is maintained for the duration of the
+application's installation on the device.
+
+## device.version
+
+Get the operating system version.
+
+    var string = device.version;
+
+### Supported Platforms
+
+- Android 2.1+
+- BlackBerry 10
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+### Quick Example
+
+    // Android:    Froyo OS would return "2.2"
+    //             Eclair OS would return "2.1", "2.0.1", or "2.0"
+    //             Version can also return update level "2.1-update1"
+    //
+    // BlackBerry: Torch 9800 using OS 6.0 would return "6.0.0.600"
+    //
+    // iPhone:     iOS 3.2 returns "3.2"
+    //
+    // Windows Phone 7: returns current OS version number, ex. on Mango returns 7.10.7720
+    // Tizen: returns "TIZEN_20120425_2"
+    var deviceVersion = device.version;
+

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/package.json
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/package.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.8",
+    "name": "org.apache.cordova.device",
+    "cordova_name": "Device",
+    "description": "Cordova Device Plugin",
+    "license": "Apache 2.0",
+    "repo": "https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git",
+    "issue": "https://issues.apache.org/jira/browse/CB/component/12320648",
+    "keywords": [
+        "cordova",
+        "device"
+    ],
+    "engines": []
+}

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/plugin.xml
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/plugin.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.apache.cordova.device"
+    version="0.2.8">
+    <name>Device</name>
+    <description>Cordova Device Plugin</description>
+    <license>Apache 2.0</license>
+    <keywords>cordova,device</keywords>
+    <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git</repo>
+    <issue>https://issues.apache.org/jira/browse/CB/component/12320648</issue>
+
+    <js-module src="www/device.js" name="device">
+        <clobbers target="device" />
+    </js-module>
+
+    <!-- firefoxos -->
+    <platform name="firefoxos">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="firefoxos-package" value="Device" />
+            </feature>
+        </config-file>
+
+        <js-module src="src/firefoxos/DeviceProxy.js" name="DeviceProxy">
+            <runs />
+        </js-module>
+    </platform>
+
+    <!-- tizen -->
+    <platform name="tizen">
+        <js-module src="src/tizen/DeviceProxy.js" name="DeviceProxy">
+            <runs />
+        </js-module>
+    </platform>
+
+    <!-- android -->
+    <platform name="android">
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="Device" >
+                <param name="android-package" value="org.apache.cordova.device.Device"/>
+            </feature>
+        </config-file>
+
+        <source-file src="src/android/Device.java" target-dir="src/org/apache/cordova/device" />
+    </platform>
+
+    <!-- amazon-fireos -->
+    <platform name="amazon-fireos">
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="Device" >
+                <param name="android-package" value="org.apache.cordova.device.Device"/>
+            </feature>
+        </config-file>
+
+        <source-file src="src/android/Device.java" target-dir="src/org/apache/cordova/device" />
+    </platform>
+    
+    <!-- ubuntu -->
+    <platform name="ubuntu">
+        <header-file src="src/ubuntu/device.h" />
+        <source-file src="src/ubuntu/device.cpp" />
+        <js-module src="src/ubuntu/device.js" name="DeviceProxy">
+            <merges target="device" />
+        </js-module>
+    </platform>
+
+    <!-- ios -->
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="ios-package" value="CDVDevice"/>
+            </feature>
+        </config-file>
+
+        <header-file src="src/ios/CDVDevice.h" />
+        <source-file src="src/ios/CDVDevice.m" />
+    </platform>
+
+    <!-- blackberry10 -->
+    <platform name="blackberry10">
+        <source-file src="src/blackberry10/index.js" target-dir="Device" />
+        <config-file target="www/config.xml" parent="/widget">
+            <feature name="Device" value="Device"/>
+        </config-file>
+        <config-file target="www/config.xml" parent="/widget/rim:permissions">
+            <rim:permit>read_device_identifying_information</rim:permit>
+        </config-file>
+    </platform>
+
+    <!-- wp7 -->
+    <platform name="wp7">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="wp-package" value="Device"/>
+            </feature>
+        </config-file>
+
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+            <Capability Name="ID_CAP_IDENTITY_DEVICE" />
+        </config-file>
+
+        <source-file src="src/wp/Device.cs" />
+    </platform>
+
+    <!-- wp8 -->
+    <platform name="wp8">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="wp-package" value="Device"/>
+            </feature>
+        </config-file>
+
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+            <Capability Name="ID_CAP_IDENTITY_DEVICE" />
+        </config-file>
+
+        <source-file src="src/wp/Device.cs" />
+    </platform>
+
+    <!-- windows8 -->
+    <platform name="windows8">
+        <js-module src="src/windows8/DeviceProxy.js" name="DeviceProxy">
+            <merges target="" />
+        </js-module>
+    </platform>
+
+</plugin>

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/android/Device.java
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/android/Device.java
@@ -1,0 +1,167 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.device;
+
+import java.util.TimeZone;
+
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaInterface;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.provider.Settings;
+
+public class Device extends CordovaPlugin {
+    public static final String TAG = "Device";
+
+    public static String cordovaVersion = "dev";              // Cordova version
+    public static String platform;                            // Device OS
+    public static String uuid;                                // Device UUID
+
+    private static final String ANDROID_PLATFORM = "Android";
+    private static final String AMAZON_PLATFORM = "amazon-fireos";
+    private static final String AMAZON_DEVICE = "Amazon";
+
+    /**
+     * Constructor.
+     */
+    public Device() {
+    }
+
+    /**
+     * Sets the context of the Command. This can then be used to do things like
+     * get file paths associated with the Activity.
+     *
+     * @param cordova The context of the main Activity.
+     * @param webView The CordovaWebView Cordova is running in.
+     */
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        super.initialize(cordova, webView);
+        Device.uuid = getUuid();
+    }
+
+    /**
+     * Executes the request and returns PluginResult.
+     *
+     * @param action            The action to execute.
+     * @param args              JSONArry of arguments for the plugin.
+     * @param callbackContext   The callback id used when calling back into JavaScript.
+     * @return                  True if the action was valid, false if not.
+     */
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        if (action.equals("getDeviceInfo")) {
+            JSONObject r = new JSONObject();
+            r.put("uuid", Device.uuid);
+            r.put("version", this.getOSVersion());
+            r.put("platform", this.getPlatform());
+            r.put("cordova", Device.cordovaVersion);
+            r.put("model", this.getModel());
+            callbackContext.success(r);
+        }
+        else {
+            return false;
+        }
+        return true;
+    }
+
+    //--------------------------------------------------------------------------
+    // LOCAL METHODS
+    //--------------------------------------------------------------------------
+
+    /**
+     * Get the OS name.
+     * 
+     * @return
+     */
+    public String getPlatform() {
+        String platform;
+        if (isAmazonDevice()) {
+            platform = AMAZON_PLATFORM;
+        } else {
+            platform = ANDROID_PLATFORM;
+        }
+        return platform;
+    }
+
+    /**
+     * Get the device's Universally Unique Identifier (UUID).
+     *
+     * @return
+     */
+    public String getUuid() {
+        String uuid = Settings.Secure.getString(this.cordova.getActivity().getContentResolver(), android.provider.Settings.Secure.ANDROID_ID);
+        return uuid;
+    }
+
+    /**
+     * Get the Cordova version.
+     *
+     * @return
+     */
+    public String getCordovaVersion() {
+        return Device.cordovaVersion;
+    }
+
+    public String getModel() {
+        String model = android.os.Build.MODEL;
+        return model;
+    }
+
+    public String getProductName() {
+        String productname = android.os.Build.PRODUCT;
+        return productname;
+    }
+
+    /**
+     * Get the OS version.
+     *
+     * @return
+     */
+    public String getOSVersion() {
+        String osversion = android.os.Build.VERSION.RELEASE;
+        return osversion;
+    }
+
+    public String getSDKVersion() {
+        @SuppressWarnings("deprecation")
+        String sdkversion = android.os.Build.VERSION.SDK;
+        return sdkversion;
+    }
+
+    public String getTimeZoneID() {
+        TimeZone tz = TimeZone.getDefault();
+        return (tz.getID());
+    }
+
+    /**
+     * Function to check if the device is manufactured by Amazon
+     * 
+     * @return
+     */
+    public boolean isAmazonDevice() {
+        if (android.os.Build.MANUFACTURER.equals(AMAZON_DEVICE)) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/blackberry10/index.js
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/blackberry10/index.js
@@ -1,0 +1,69 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+function getModelName () {
+    var modelName = window.qnx.webplatform.device.modelName;
+    //Pre 10.2 (meaning Z10 or Q10)
+    if (typeof modelName === "undefined") {
+        if (window.screen.height === 720 && window.screen.width === 720) {
+            if ( window.matchMedia("(-blackberry-display-technology: -blackberry-display-oled)").matches) {
+                modelName = "Q10";
+            } else {
+                modelName = "Q5";
+            }
+        } else if ((window.screen.height === 1280 && window.screen.width === 768) ||
+                   (window.screen.height === 768 && window.screen.width === 1280)) {
+            modelName = "Z10";
+        } else {
+            modelName = window.qnx.webplatform.deviceName;
+        }
+    }
+
+    return modelName;
+}
+
+function getUUID () {
+    var uuid = "";
+    try {
+        //Must surround by try catch because this will throw if the app is missing permissions
+        uuid = window.qnx.webplatform.device.devicePin;
+    } catch (e) {
+        //DO Nothing
+    }
+    return uuid;
+}
+
+module.exports = {
+    getDeviceInfo: function (success, fail, args, env) {
+        var result = new PluginResult(args, env),
+            modelName = getModelName(),
+            uuid = getUUID(),
+            info = {
+                platform: "blackberry10",
+                version: window.qnx.webplatform.device.scmBundle,
+                model: modelName,
+                uuid: uuid,
+                cordova: "dev"
+            };
+
+        result.ok(info);
+    }
+};

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/firefoxos/DeviceProxy.js
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/firefoxos/DeviceProxy.js
@@ -1,0 +1,39 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var firefoxos = require('cordova/platform');
+var cordova = require('cordova');
+
+module.exports = {
+    getDeviceInfo: function(success, error) {
+        setTimeout(function () {
+            success({
+                cordova: firefoxos.cordovaVersion,
+                platform: 'firefoxos',
+                model: null,
+                version: null,
+                uuid: null
+            });
+        }, 0);
+    }
+};
+
+require("cordova/firefoxos/commandProxy").add("Device", module.exports);

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ios/CDVDevice.h
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ios/CDVDevice.h
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import <Cordova/CDVPlugin.h>
+
+@interface CDVDevice : CDVPlugin
+{}
+
++ (NSString*)cordovaVersion;
+
+- (void)getDeviceInfo:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ios/CDVDevice.m
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ios/CDVDevice.m
@@ -1,0 +1,90 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+#import <Cordova/CDV.h>
+#import "CDVDevice.h"
+
+@implementation UIDevice (ModelVersion)
+
+- (NSString*)modelVersion
+{
+    size_t size;
+
+    sysctlbyname("hw.machine", NULL, &size, NULL, 0);
+    char* machine = malloc(size);
+    sysctlbyname("hw.machine", machine, &size, NULL, 0);
+    NSString* platform = [NSString stringWithUTF8String:machine];
+    free(machine);
+
+    return platform;
+}
+
+@end
+
+@interface CDVDevice () {}
+@end
+
+@implementation CDVDevice
+
+- (void)getDeviceInfo:(CDVInvokedUrlCommand*)command
+{
+    NSDictionary* deviceProperties = [self deviceProperties];
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:deviceProperties];
+
+    /* Settings.plist
+     * Read the optional Settings.plist file and push these user-defined settings down into the web application.
+     * This can be useful for supplying build-time configuration variables down to the app to change its behavior,
+     * such as specifying Full / Lite version, or localization (English vs German, for instance).
+     */
+    // TODO: turn this into an iOS only plugin
+    NSDictionary* temp = [CDVViewController getBundlePlist:@"Settings"];
+
+    if ([temp respondsToSelector:@selector(JSONString)]) {
+        NSLog(@"Deprecation warning: window.Setting will be removed Aug 2013. Refer to https://issues.apache.org/jira/browse/CB-2433");
+        NSString* js = [NSString stringWithFormat:@"window.Settings = %@;", [temp JSONString]];
+        [self.commandDelegate evalJs:js];
+    }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (NSDictionary*)deviceProperties
+{
+    UIDevice* device = [UIDevice currentDevice];
+    NSMutableDictionary* devProps = [NSMutableDictionary dictionaryWithCapacity:4];
+
+    [devProps setObject:[device modelVersion] forKey:@"model"];
+    [devProps setObject:@"iOS" forKey:@"platform"];
+    [devProps setObject:[device systemVersion] forKey:@"version"];
+    [devProps setObject:[device uniqueAppInstanceIdentifier] forKey:@"uuid"];
+    [devProps setObject:[[self class] cordovaVersion] forKey:@"cordova"];
+
+    NSDictionary* devReturn = [NSDictionary dictionaryWithDictionary:devProps];
+    return devReturn;
+}
+
++ (NSString*)cordovaVersion
+{
+    return CDV_VERSION;
+}
+
+@end

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/tizen/DeviceProxy.js
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/tizen/DeviceProxy.js
@@ -1,0 +1,39 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var tizen = require('cordova/platform');
+var cordova = require('cordova');
+
+module.exports = {
+    getDeviceInfo: function(success, error) {
+        setTimeout(function () {
+            success({
+                cordova: tizen.cordovaVersion,
+                platform: 'tizen',
+                model: null,
+                version: null,
+                uuid: null
+            });
+        }, 0);
+    }
+};
+
+require("cordova/tizen/commandProxy").add("Device", module.exports);

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ubuntu/device.cpp
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ubuntu/device.cpp
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2011 Wolfgang Koller - http://www.gofg.at/
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <QDeviceInfo>
+#include <QtSystemInfo>
+
+#include"device.h"
+
+#define CORDOVA "3.0.0"
+
+Device::Device(Cordova *cordova) : CPlugin(cordova) {
+}
+
+static QString getOSName() {
+#ifdef Q_OS_SYMBIAN
+    QString platform = "Symbian";
+#endif
+#ifdef Q_OS_WIN
+    QString platform = "Windows";
+#endif
+#ifdef Q_OS_WINCE
+    QString platform = "Windows CE";
+#endif
+#ifdef Q_OS_LINUX
+    QString platform = "Linux";
+#endif
+    return platform;
+}
+
+void Device::getInfo(int scId, int ecId) {
+    Q_UNUSED(ecId)
+
+    QDeviceInfo systemDeviceInfo;
+    QDeviceInfo systemInfo;
+
+    QString platform = getOSName();
+
+    QString uuid = systemDeviceInfo.uniqueDeviceID();
+    if (uuid.isEmpty()) {
+        QString deviceDescription = systemInfo.imei(0) + ";" + systemInfo.manufacturer() + ";" + systemInfo.model() + ";" + systemInfo.productName() + ";" + platform;
+        QString user = qgetenv("USER");
+        if (user.isEmpty()) {
+            user = qgetenv("USERNAME");
+            if (user.isEmpty())
+                user = QDir::homePath();
+        }
+        uuid = QString(QCryptographicHash::hash((deviceDescription + ";" + user).toUtf8(), QCryptographicHash::Md5).toHex());
+    }
+
+    this->cb(scId, systemDeviceInfo.model(), CORDOVA, platform, uuid, systemInfo.version(QDeviceInfo::Os));
+}

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ubuntu/device.h
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ubuntu/device.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2011 Wolfgang Koller - http://www.gofg.at/
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef DEVICE_H_FDSAFAS
+#define DEVICE_H_FDSAFAS
+
+#include <QtCore>
+
+#include <cplugin.h>
+
+class Device: public CPlugin {
+    Q_OBJECT
+public:
+    explicit Device(Cordova *cordova);
+
+    virtual const QString fullName() override {
+        return Device::fullID();
+    }
+
+    virtual const QString shortName() override {
+        return "Device";
+    }
+
+    static const QString fullID() {
+        return "com.cordova.Device";
+    }
+
+signals:
+
+public slots:
+    void getInfo(int scId, int ecId);
+};
+
+#endif

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ubuntu/device.js
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/ubuntu/device.js
@@ -1,0 +1,34 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var cordova = require('cordova');
+var exec = require('cordova/exec');
+
+module.exports = {
+    getInfo:function(win,fail,args) {
+        Cordova.exec(function (model, cordova, platform, uuid, version) {
+            win({name: name, model: model, cordova: cordova,
+                 platform: platform, uuid: uuid, version: version});
+        }, null, "com.cordova.Device", "getInfo", []);
+    }
+};
+
+require("cordova/exec/proxy").add("Device", module.exports);

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/windows8/DeviceProxy.js
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/windows8/DeviceProxy.js
@@ -1,0 +1,50 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+
+var cordova = require('cordova');
+var utils = require('cordova/utils');
+
+module.exports = {
+
+    getDeviceInfo:function(win,fail,args) {
+
+        // deviceId aka uuid, stored in Windows.Storage.ApplicationData.current.localSettings.values.deviceId
+        var deviceId;
+
+        var localSettings = Windows.Storage.ApplicationData.current.localSettings;
+
+        if (localSettings.values.deviceId) {
+            deviceId = localSettings.values.deviceId;
+        }
+        else {
+            deviceId = localSettings.values.deviceId = utils.createUUID();
+        }
+
+        setTimeout(function () {
+            win({ platform: "windows8", version: "8", uuid: deviceId, cordova: '0.0.0', model: window.clientInformation.platform });
+        }, 0);
+    }
+
+};
+
+require("cordova/windows8/commandProxy").add("Device", module.exports);
+

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/wp/Device.cs
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/src/wp/Device.cs
@@ -1,0 +1,135 @@
+﻿/*  
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Net;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Ink;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Shapes;
+using Microsoft.Phone.Info;
+using System.IO.IsolatedStorage;
+using System.Windows.Resources;
+using System.IO;
+using System.Diagnostics;
+
+namespace WPCordovaClassLib.Cordova.Commands
+{
+    public class Device : BaseCommand
+    {
+        public void getDeviceInfo(string notused)
+        {
+
+            string res = String.Format("\"name\":\"{0}\",\"cordova\":\"{1}\",\"platform\":\"{2}\",\"uuid\":\"{3}\",\"version\":\"{4}\",\"model\":\"{5}\"",
+                                        this.name,
+                                        this.cordova,
+                                        this.platform,
+                                        this.uuid,
+                                        this.version,
+                                        this.model);
+
+
+
+            res = "{" + res + "}";
+            //Debug.WriteLine("Result::" + res);
+            DispatchCommandResult(new PluginResult(PluginResult.Status.OK, res));
+        }
+
+        public string model
+        {
+            get
+            {
+                return DeviceStatus.DeviceName;
+                //return String.Format("{0},{1},{2}", DeviceStatus.DeviceManufacturer, DeviceStatus.DeviceHardwareVersion, DeviceStatus.DeviceFirmwareVersion); 
+            }
+        }
+
+        public string name
+        {
+            get
+            {
+                return DeviceStatus.DeviceName;
+                
+            }
+        }
+
+        public string cordova
+        {
+            get
+            {
+                // TODO: should be able to dynamically read the Cordova version from somewhere...
+                return "3.0.0";
+            }
+        }
+
+        public string platform
+        {
+            get
+            {
+                return Environment.OSVersion.Platform.ToString();
+            }
+        }
+
+        public string uuid
+        {
+            get
+            {
+                string returnVal = "";
+                object id;
+                UserExtendedProperties.TryGetValue("ANID", out id);
+
+                if (id != null)
+                {
+                    returnVal = id.ToString().Substring(2, 32);
+                }
+                else
+                {
+                    returnVal = "???unknown???";
+
+                    using (IsolatedStorageFile appStorage = IsolatedStorageFile.GetUserStoreForApplication())
+                    {
+                        try
+                        {
+                            IsolatedStorageFileStream fileStream = new IsolatedStorageFileStream("DeviceID.txt", FileMode.Open, FileAccess.Read, appStorage);
+
+                            using (StreamReader reader = new StreamReader(fileStream))
+                            {
+                                returnVal = reader.ReadLine();
+                            }
+                        }
+                        catch (Exception /*ex*/)
+                        {
+
+                        }
+                    }
+                }
+
+                return returnVal;
+            }
+        }
+
+        public string version
+        {
+            get
+            {
+                return Environment.OSVersion.Version.ToString();
+            }
+        }
+
+    }
+}

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/www/device.js
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.device/www/device.js
@@ -1,0 +1,77 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    channel = require('cordova/channel'),
+    utils = require('cordova/utils'),
+    exec = require('cordova/exec'),
+    cordova = require('cordova');
+
+channel.createSticky('onCordovaInfoReady');
+// Tell cordova channel to wait on the CordovaInfoReady event
+channel.waitForInitialization('onCordovaInfoReady');
+
+/**
+ * This represents the mobile device, and provides properties for inspecting the model, version, UUID of the
+ * phone, etc.
+ * @constructor
+ */
+function Device() {
+    this.available = false;
+    this.platform = null;
+    this.version = null;
+    this.uuid = null;
+    this.cordova = null;
+    this.model = null;
+
+    var me = this;
+
+    channel.onCordovaReady.subscribe(function() {
+        me.getInfo(function(info) {
+            //ignoring info.cordova returning from native, we should use value from cordova.version defined in cordova.js
+            //TODO: CB-5105 native implementations should not return info.cordova
+            var buildLabel = cordova.version;
+            me.available = true;
+            me.platform = info.platform;
+            me.version = info.version;
+            me.uuid = info.uuid;
+            me.cordova = buildLabel;
+            me.model = info.model;
+            channel.onCordovaInfoReady.fire();
+        },function(e) {
+            me.available = false;
+            utils.alert("[ERROR] Error initializing Cordova: " + e);
+        });
+    });
+}
+
+/**
+ * Get device info
+ *
+ * @param {Function} successCallback The function to call when the heading data is available
+ * @param {Function} errorCallback The function to call when there is an error getting the heading data. (OPTIONAL)
+ */
+Device.prototype.getInfo = function(successCallback, errorCallback) {
+    argscheck.checkArgs('fF', 'Device.getInfo', arguments);
+    exec(successCallback, errorCallback, "Device", "getDeviceInfo", []);
+};
+
+module.exports = new Device();

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/README.md
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/README.md
@@ -1,0 +1,186 @@
+StatusBar
+======
+
+> The `StatusBar` object provides some functions to customize the iOS StatusBar.
+
+The plugin reads the __StatusBarOverlaysWebView__ (boolean, defaults to true) and __StatusBarBackgroundColor__ (color hex string, defaults to #000000) values from config.xml.
+ 
+Methods
+-------
+
+- StatusBar.overlaysWebView
+- StatusBar.styleDefault
+- StatusBar.styleLightContent
+- StatusBar.styleBlackTranslucent
+- StatusBar.styleBlackOpaque
+- StatusBar.backgroundColorByName
+- StatusBar.backgroundColorByHexString
+- StatusBar.hide
+- StatusBar.show
+
+Properties
+--------
+
+- StatusBar.isVisible
+
+Permissions
+-----------
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+
+StatusBar.overlaysWebView
+=================
+
+On iOS 7, make the statusbar overlay or not overlay the WebView.
+
+    StatusBar.overlaysWebView(true);
+
+Description
+-----------
+
+On iOS 7, set to false to make the statusbar appear like iOS 6. Set the style and background color to suit using the other functions.
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+Quick Example
+-------------
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+
+StatusBar.styleDefault
+=================
+
+Use the default statusbar (dark text, for light backgrounds).
+
+    StatusBar.styleDefault();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.styleLightContent
+=================
+
+Use the lightContent statusbar (light text, for dark backgrounds).
+
+    StatusBar.styleLightContent();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.styleBlackTranslucent
+=================
+
+Use the blackTranslucent statusbar (light text, for dark backgrounds).
+
+    StatusBar.styleBlackTranslucent();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.styleBlackOpaque
+=================
+
+Use the blackOpaque statusbar (light text, for dark backgrounds).
+
+    StatusBar.styleBlackOpaque();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+
+StatusBar.backgroundColorByName
+=================
+
+On iOS 7, when you set StatusBar.statusBarOverlaysWebView to false, you can set the background color of the statusbar by color name.
+
+    StatusBar.backgroundColorByName("red");
+
+Supported color names are:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown, clear
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.backgroundColorByHexString
+=================
+
+On iOS 7, when you set StatusBar.statusBarOverlaysWebView to false, you can set the background color of the statusbar by a hex string (#RRGGBB).
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.hide
+=================
+
+Hide the statusbar.
+
+    StatusBar.hide();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.show
+=================
+
+Shows the statusbar.
+
+    StatusBar.show();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+
+StatusBar.isVisible
+=================
+
+Read this property to see if the statusbar is visible or not.
+
+    if (StatusBar.isVisible) {
+    	// do something
+    }
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+
+
+    

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/package.json
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/package.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.1.3",
+    "name": "org.apache.cordova.statusbar",
+    "cordova_name": "StatusBar",
+    "description": "Cordova StatusBar Plugin",
+    "license": "Apache 2.0",
+    "keywords": [
+        "cordova",
+        "statusbar"
+    ],
+    "engines": [
+        {
+            "name": "cordova",
+            "version": ">=3.0.0"
+        }
+    ]
+}

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/plugin.xml
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/plugin.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.apache.cordova.statusbar"
+    version="0.1.3">
+    <name>StatusBar</name>
+    <description>Cordova StatusBar Plugin</description>
+    <license>Apache 2.0</license>
+    <keywords>cordova,statusbar</keywords>
+
+	<engines>
+		<engine name="cordova" version=">=3.0.0" />
+	</engines>
+
+    <js-module src="www/statusbar.js" name="statusbar">
+    	<clobbers target="window.StatusBar" />
+    </js-module>
+
+    <!-- ios -->
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+            <preference name="StatusBarOverlaysWebView" value="true" />
+            <preference name="StatusBarBackgroundColor" value="#000000" />
+        </config-file>
+        
+        <header-file src="src/ios/CDVStatusBar.h" />
+        <source-file src="src/ios/CDVStatusBar.m" />
+        
+    </platform>
+
+</plugin>

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/src/ios/CDVStatusBar.h
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/src/ios/CDVStatusBar.h
@@ -1,0 +1,51 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVInvokedUrlCommand.h>
+
+@interface CDVStatusBar : CDVPlugin {
+    @protected
+    BOOL _statusBarOverlaysWebView;
+    @protected
+    UIView* _statusBarBackgroundView;
+    @protected
+    BOOL _uiviewControllerBasedStatusBarAppearance;
+    @protected
+    UIColor* _statusBarBackgroundColor;
+}
+
+@property (atomic, assign) BOOL statusBarOverlaysWebView;
+
+- (void) overlaysWebView:(CDVInvokedUrlCommand*)command;
+
+- (void) styleDefault:(CDVInvokedUrlCommand*)command;
+- (void) styleLightContent:(CDVInvokedUrlCommand*)command;
+- (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command;
+- (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command;
+
+- (void) backgroundColorByName:(CDVInvokedUrlCommand*)command;
+- (void) backgroundColorByHexString:(CDVInvokedUrlCommand*)command;
+
+- (void) hide:(CDVInvokedUrlCommand*)command;
+- (void) show:(CDVInvokedUrlCommand*)command;
+    
+- (void) _ready:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/src/ios/CDVStatusBar.m
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/src/ios/CDVStatusBar.m
@@ -1,0 +1,401 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+/* 
+ NOTE: plugman/cordova cli should have already installed this,
+ but you need the value UIViewControllerBasedStatusBarAppearance
+ in your Info.plist as well to set the styles in iOS 7
+ */
+
+#import "CDVStatusBar.h"
+#import <objc/runtime.h>
+#import <Cordova/CDVViewController.h>
+
+static const void *kHideStatusBar = &kHideStatusBar;
+static const void *kStatusBarStyle = &kStatusBarStyle;
+
+@interface CDVViewController (StatusBar)
+
+@property (nonatomic, retain) id sb_hideStatusBar;
+@property (nonatomic, retain) id sb_statusBarStyle;
+    
+@end
+
+@implementation CDVViewController (StatusBar)
+
+@dynamic sb_hideStatusBar;
+@dynamic sb_statusBarStyle;
+    
+- (id)sb_hideStatusBar {
+    return objc_getAssociatedObject(self, kHideStatusBar);
+}
+    
+- (void)setSb_hideStatusBar:(id)newHideStatusBar {
+    objc_setAssociatedObject(self, kHideStatusBar, newHideStatusBar, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (id)sb_statusBarStyle {
+    return objc_getAssociatedObject(self, kStatusBarStyle);
+}
+    
+- (void)setSb_statusBarStyle:(id)newStatusBarStyle {
+    objc_setAssociatedObject(self, kStatusBarStyle, newStatusBarStyle, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+    
+- (BOOL) prefersStatusBarHidden {
+    return [self.sb_hideStatusBar boolValue];
+}
+    
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return (UIStatusBarStyle)[self.sb_statusBarStyle intValue];
+}
+    
+@end
+
+
+@implementation CDVStatusBar
+
+- (id)settingForKey:(NSString*)key
+{
+    return [self.commandDelegate.settings objectForKey:[key lowercaseString]];
+}
+
+- (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)context
+{
+    if ([keyPath isEqual:@"statusBarHidden"]) {
+        NSNumber* newValue = [change objectForKey:NSKeyValueChangeNewKey];
+        BOOL boolValue = [newValue boolValue];
+
+        [self.commandDelegate evalJs:[NSString stringWithFormat:@"StatusBar.isVisible = %@;", boolValue? @"false" : @"true" ]];
+    }
+}
+
+- (void)pluginInitialize
+{
+    BOOL isiOS7 = (IsAtLeastiOSVersion(@"7.0"));
+                   
+    // init
+    NSNumber* uiviewControllerBasedStatusBarAppearance = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"];
+    _uiviewControllerBasedStatusBarAppearance = (uiviewControllerBasedStatusBarAppearance == nil || [uiviewControllerBasedStatusBarAppearance boolValue]) && isiOS7;
+    
+    // observe the statusBarHidden property
+    [[UIApplication sharedApplication] addObserver:self forKeyPath:@"statusBarHidden" options:NSKeyValueObservingOptionNew context:NULL];
+    
+    _statusBarOverlaysWebView = YES; // default
+    
+    [self initializeStatusBarBackgroundView];
+    
+    [self styleLightContent:nil]; // match default backgroundColor of #000000
+    self.viewController.view.autoresizesSubviews = YES;
+    
+    NSString* setting;
+    
+    setting  = @"StatusBarOverlaysWebView";
+    if ([self settingForKey:setting]) {
+        self.statusBarOverlaysWebView = [(NSNumber*)[self settingForKey:setting] boolValue];
+    }
+
+    setting  = @"StatusBarBackgroundColor";
+    if ([self settingForKey:setting]) {
+        [self _backgroundColorByHexString:[self settingForKey:setting]];
+    }
+}
+
+- (void) _ready:(CDVInvokedUrlCommand*)command
+{
+    // set the initial value
+    [self.commandDelegate evalJs:[NSString stringWithFormat:@"StatusBar.isVisible = %@;", [UIApplication sharedApplication].statusBarHidden? @"false" : @"true" ]];
+}
+
+- (void) initializeStatusBarBackgroundView 
+{
+    CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+    if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+        // swap width and height. set origin to zero
+        statusBarFrame = CGRectMake(0, 0, statusBarFrame.size.height, statusBarFrame.size.width);
+    }
+
+    _statusBarBackgroundView = [[UIView alloc] initWithFrame:statusBarFrame];
+    _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
+    _statusBarBackgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth  | UIViewAutoresizingFlexibleBottomMargin);
+    _statusBarBackgroundView.autoresizesSubviews = YES;
+}
+
+- (void) setStatusBarOverlaysWebView:(BOOL)statusBarOverlaysWebView
+{
+    // we only care about the latest iOS version or a change in setting
+    if (!IsAtLeastiOSVersion(@"7.0") || statusBarOverlaysWebView == _statusBarOverlaysWebView) {
+        return;
+    }
+
+    CGRect bounds = [[UIScreen mainScreen] bounds];
+    
+    if (statusBarOverlaysWebView) {
+        
+        [_statusBarBackgroundView removeFromSuperview];
+        self.webView.frame = bounds;
+
+    } else {
+
+        CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+
+        [self initializeStatusBarBackgroundView];
+
+        CGRect frame = self.webView.frame;
+
+        if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+            frame.origin.y = statusBarFrame.size.width;
+            frame.size.height -= statusBarFrame.size.width;
+        } else {
+            frame.origin.y = statusBarFrame.size.height;
+            frame.size.height -= statusBarFrame.size.height;
+        }
+        
+        self.webView.frame = frame;
+        [self.webView.superview addSubview:_statusBarBackgroundView];
+    }
+    
+    _statusBarOverlaysWebView = statusBarOverlaysWebView;
+}
+
+- (BOOL) statusBarOverlaysWebView
+{
+    return _statusBarOverlaysWebView;
+}
+
+- (void) overlaysWebView:(CDVInvokedUrlCommand*)command
+{
+    id value = [command.arguments objectAtIndex:0];
+    if (!([value isKindOfClass:[NSNumber class]])) {
+        value = [NSNumber numberWithBool:YES];
+    }
+    
+    self.statusBarOverlaysWebView = [value boolValue];
+}
+
+- (void) refreshStatusBarAppearance
+{
+    SEL sel = NSSelectorFromString(@"setNeedsStatusBarAppearanceUpdate");
+    if ([self.viewController respondsToSelector:sel]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [self.viewController performSelector:sel withObject:nil];
+#pragma clang diagnostic pop
+    }
+}
+    
+- (void) setStyleForStatusBar:(UIStatusBarStyle)style
+{
+    if (_uiviewControllerBasedStatusBarAppearance) {
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        vc.sb_statusBarStyle = [NSNumber numberWithInt:style];
+        [self refreshStatusBarAppearance];
+        
+    } else {
+        [[UIApplication sharedApplication] setStatusBarStyle:style];
+    }
+}
+    
+- (void) setStatusBarStyle:(NSString*)statusBarStyle
+{
+    // default, lightContent, blackTranslucent, blackOpaque
+    NSString* lcStatusBarStyle = [statusBarStyle lowercaseString];
+    
+    if ([lcStatusBarStyle isEqualToString:@"default"]) {
+        [self styleDefault:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"lightcontent"]) {
+        [self styleLightContent:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"blacktranslucent"]) {
+        [self styleBlackTranslucent:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"blackopaque"]) {
+        [self styleBlackOpaque:nil];
+    }
+}
+
+- (void) styleDefault:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleDefault];
+}
+
+- (void) styleLightContent:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleLightContent];
+}
+
+- (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleBlackTranslucent];
+}
+
+- (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleBlackOpaque];
+}
+
+- (void) backgroundColorByName:(CDVInvokedUrlCommand*)command
+{
+    id value = [command.arguments objectAtIndex:0];
+    if (!([value isKindOfClass:[NSString class]])) {
+        value = @"black";
+    }
+    
+    SEL selector = NSSelectorFromString([value stringByAppendingString:@"Color"]);
+    if ([UIColor respondsToSelector:selector]) {
+        _statusBarBackgroundView.backgroundColor = [UIColor performSelector:selector];
+    }
+}
+
+- (void) _backgroundColorByHexString:(NSString*)hexString
+{
+    unsigned int rgbValue = 0;
+    NSScanner* scanner = [NSScanner scannerWithString:hexString];
+    [scanner setScanLocation:1];
+    [scanner scanHexInt:&rgbValue];
+    
+    _statusBarBackgroundColor = [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+    _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
+}
+
+- (void) backgroundColorByHexString:(CDVInvokedUrlCommand*)command
+{
+    NSString* value = [command.arguments objectAtIndex:0];
+    if (!([value isKindOfClass:[NSString class]])) {
+        value = @"#000000";
+    }
+    
+    if (![value hasPrefix:@"#"] || [value length] < 7) {
+        return;
+    }
+    
+    [self _backgroundColorByHexString:value];
+}
+
+- (void) hideStatusBar
+{
+    if (_uiviewControllerBasedStatusBarAppearance) {
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        vc.sb_hideStatusBar = [NSNumber numberWithBool:YES];
+        [self refreshStatusBarAppearance];
+
+    } else {
+        UIApplication* app = [UIApplication sharedApplication];
+        [app setStatusBarHidden:YES];
+    }
+}
+    
+- (void) hide:(CDVInvokedUrlCommand*)command
+{
+    UIApplication* app = [UIApplication sharedApplication];
+    
+    if (!app.isStatusBarHidden)
+    {
+        self.viewController.wantsFullScreenLayout = YES;
+        CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+        
+        [self hideStatusBar];
+
+        if (IsAtLeastiOSVersion(@"7.0")) {
+            [_statusBarBackgroundView removeFromSuperview];
+        }
+        
+        CGRect frame = self.webView.frame;
+        frame.origin.y = 0;
+        
+        if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+            frame.size.height += statusBarFrame.size.width;
+        } else {
+            frame.size.height += statusBarFrame.size.height;
+        }
+        
+        self.webView.frame = frame;
+        _statusBarBackgroundView.hidden = YES;
+    }
+}
+    
+- (void) showStatusBar
+{
+    if (_uiviewControllerBasedStatusBarAppearance) {
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        vc.sb_hideStatusBar = [NSNumber numberWithBool:NO];
+        [self refreshStatusBarAppearance];
+
+    } else {
+        UIApplication* app = [UIApplication sharedApplication];
+        [app setStatusBarHidden:NO];
+    }
+}
+    
+- (void) show:(CDVInvokedUrlCommand*)command
+{
+    UIApplication* app = [UIApplication sharedApplication];
+    
+    if (app.isStatusBarHidden)
+    {
+        BOOL isIOS7 = (IsAtLeastiOSVersion(@"7.0"));
+        self.viewController.wantsFullScreenLayout = isIOS7;
+        
+        [self showStatusBar];
+        
+        if (isIOS7) {
+            CGRect frame = self.webView.frame;
+            self.viewController.view.frame = [[UIScreen mainScreen] bounds];
+            
+            CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+            
+            if (!self.statusBarOverlaysWebView) {
+                
+                // there is a possibility that when the statusbar was hidden, it was in a different orientation
+                // from the current one. Therefore we need to expand the statusBarBackgroundView as well to the
+                // statusBar's current size
+                CGRect sbBgFrame = _statusBarBackgroundView.frame;
+                
+                if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+                    frame.origin.y = statusBarFrame.size.width;
+                    frame.size.height -= statusBarFrame.size.width;
+                    sbBgFrame.size = CGSizeMake(statusBarFrame.size.height, statusBarFrame.size.width);
+                } else {
+                    frame.origin.y = statusBarFrame.size.height;
+                    frame.size.height -= statusBarFrame.size.height;
+                    sbBgFrame.size = statusBarFrame.size;
+                }
+                
+                _statusBarBackgroundView.frame = sbBgFrame;
+                [self.webView.superview addSubview:_statusBarBackgroundView];
+            }
+
+            self.webView.frame = frame;
+            
+        } else {
+            
+            CGRect bounds = [[UIScreen mainScreen] applicationFrame];
+            self.viewController.view.frame = bounds;
+        }
+        
+        _statusBarBackgroundView.hidden = NO;
+    }
+}
+
+- (void) dealloc
+{
+    [[UIApplication sharedApplication] removeObserver:self forKeyPath:@"statusBarHidden"];
+}
+
+
+@end

--- a/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/www/statusbar.js
+++ b/kitchensink-cordova-contacts/plugins/org.apache.cordova.statusbar/www/statusbar.js
@@ -1,0 +1,70 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    utils = require('cordova/utils'),
+    exec = require('cordova/exec');
+
+// prime it
+exec(null, null, "StatusBar", "_ready", []);
+
+var StatusBar = function() {
+};
+
+StatusBar.overlaysWebView = function(doOverlay) {
+    exec(null, null, "StatusBar", "overlaysWebView", [doOverlay]);
+};
+
+StatusBar.styleDefault = function() {
+    exec(null, null, "StatusBar", "styleDefault", []);
+};
+
+StatusBar.styleLightContent = function() {
+    exec(null, null, "StatusBar", "styleLightContent", []);
+};
+
+StatusBar.styleBlackTranslucent = function() {
+    exec(null, null, "StatusBar", "styleBlackTranslucent", []);
+};
+
+StatusBar.styleBlackOpaque = function() {
+    exec(null, null, "StatusBar", "styleBlackOpaque", []);
+};
+
+StatusBar.backgroundColorByName = function(colorname) {
+    exec(null, null, "StatusBar", "backgroundColorByName", [colorname]);
+}
+
+StatusBar.backgroundColorByHexString = function(hexString) {
+    exec(null, null, "StatusBar", "backgroundColorByHexString", [hexString]);
+}
+
+StatusBar.hide = function() {
+    exec(null, null, "StatusBar", "hide", []);
+}
+
+StatusBar.show = function() {
+    exec(null, null, "StatusBar", "show", []);
+}
+
+StatusBar.isVisible = true;
+
+module.exports = StatusBar;

--- a/kitchensink-cordova-contacts/www/config.xml
+++ b/kitchensink-cordova-contacts/www/config.xml
@@ -1,15 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <widget xmlns="http://www.w3.org/ns/widgets" xmlns:gap="http://phonegap.com/ns/1.0"
-	id="org.jboss.quickstarts.wfk.kitchensinkcordova" version="2.0.0">
-	<name>kitchensink-cordova</name>
+	id="org.jboss.quickstarts.wfk.kitchensinkcordovacontacts" version="2.0.0">
+	<name>kitchensink-cordova-contacts</name>
 
 	<description>
-		A sample Apache Cordova application that responds to the
-		deviceready
-		event.
+		A sample Apache Cordova application that utilizes the Cordova Contacts API
+		to search for contacts on the device or to save contacts to it.
 	</description>
 
-	<author href="http://aerogear.org/" email="aerogear-dev@lists.jboss.org">
+	<author href="http://www.jboss.org/jdf/" email="jdf-users@lists.jboss.org">
 		JBoss by Red Hat
 	</author>
 
@@ -22,12 +21,12 @@
 	<feature name="App">
 		<param name="android-package" value="org.apache.cordova.App" />
 	</feature>
-	
+
 	<feature name="Contacts">
 		<param name="android-package" value="org.apache.cordova.contacts.ContactManager" />
 		<param name="ios-package" value="CDVContacts" />
 	</feature>
-	
+
 	<feature name="Notification">
 		<param name="android-package" value="org.apache.cordova.dialogs.Notification" />
 		<param name="ios-package" value="CDVNotification" />
@@ -36,6 +35,13 @@
 		<param name="android-package" value="org.apache.cordova.vibration.Vibration" />
 		<param name="ios-package" value="CDVVibration" />
 	</feature>
-	
+	<feature name="StatusBar">
+		<param name="ios-package" value="CDVStatusBar" />
+	</feature>
+	<feature name="Device">
+		<param name="android-package" value="org.apache.cordova.device.Device" />
+		<param name="ios-package" value="CDVDevice" />
+	</feature>
+
 
 </widget>

--- a/kitchensink-cordova-contacts/www/css/screen.css
+++ b/kitchensink-cordova-contacts/www/css/screen.css
@@ -153,6 +153,10 @@ span.success {
     background-image: linear-gradient( #EEE, #DDD);
 }
 
+.ui-header {
+	border-top: 1px solid #81B9EF
+}
+
 .app-responsive .ui-block-a,
 .app-responsive .ui-block-b,
 .app-responsive .ui-block-c,

--- a/kitchensink-cordova-contacts/www/index.html
+++ b/kitchensink-cordova-contacts/www/index.html
@@ -67,6 +67,13 @@
 		$.when(deviceReadyDeferred, jqmReadyDeferred, appStartDeferred).done(doInit);
 		
 		function deviceReady() {
+	        // Detect if iOS 7 or higher and disable overlaying the status bar
+	        if(window.device.platform.toLowerCase() == "ios" &&
+	            parseFloat(window.device.version) >= 7.0) {
+	            StatusBar.overlaysWebView(false);
+	            StatusBar.styleDefault();
+	            StatusBar.backgroundColorByHexString("#81B9EF");
+	        }
             // Mark the Deferred object as resolved.
 		    deviceReadyDeferred.resolve();
 		}

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/.npmignore
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/.npmignore
@@ -1,0 +1,23 @@
+﻿#If ignorance is bliss, then somebody knock the smile off my face
+
+*.csproj.user
+*.suo
+*.cache
+Thumbs.db
+*.DS_Store
+
+*.bak
+*.cache
+*.log
+*.swp
+*.user
+
+
+
+
+
+
+
+
+
+ 

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/LICENSE
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/README.md
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/README.md
@@ -1,0 +1,22 @@
+<!---
+ license: Licensed to the Apache Software Foundation (ASF) under one
+         or more contributor license agreements.  See the NOTICE file
+         distributed with this work for additional information
+         regarding copyright ownership.  The ASF licenses this file
+         to you under the Apache License, Version 2.0 (the
+         "License"); you may not use this file except in compliance
+         with the License.  You may obtain a copy of the License at
+
+           http://www.apache.org/licenses/LICENSE-2.0
+
+         Unless required by applicable law or agreed to in writing,
+         software distributed under the License is distributed on an
+         "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+         KIND, either express or implied.  See the License for the
+         specific language governing permissions and limitations
+         under the License.
+-->
+
+# org.apache.cordova.device
+
+Plugin documentation: [doc/index.md](doc/index.md)

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/RELEASENOTES.md
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/RELEASENOTES.md
@@ -1,0 +1,57 @@
+<!--
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+-->
+# Release Notes
+
+### 0.2.1 (Sept 5, 2013)
+* removed extraneous print statement
+* [CB-4432] copyright notice change
+
+### 0.2.3 (Sept 25, 2013)
+* CB-4889 bumping&resetting version
+* [windows8] commandProxy has moved
+* [BlackBerry10] removed uneeded permission tags in plugin.xml
+* CB-4889 renaming org.apache.cordova.core.device to org.apache.cordova.device
+* Rename CHANGELOG.md -> RELEASENOTES.md
+* updated to use commandProxy for ffos
+* add firefoxos support
+* [CB-4752] Incremented plugin version on dev branch. 
+
+### 0.2.4 (Oct 28, 2013)
+* CB-5128: added repo + issue tag in plugin.xml for device plugin
+* CB-5085 device.cordova returning wrong value
+* [CB-4915] Incremented plugin version on dev branch.
+
+### 0.2.5 (Dec 4, 2013)
+* CB-5316 Spell Cordova as a brand unless it's a command or script
+* [ubuntu] use cordova/exec/proxy
+* add ubuntu platform
+* Modify Device.platform logic to use amazon-fireos as the platform for Amazon Devices
+* 1. Added amazon-fireos platform. 2. Change to use cordova-amazon-fireos as the platform if user agent contains 'cordova-amazon-fireos'
+
+### 0.2.6 (Jan 02, 2014)
+* CB-5658 Add doc/index.md for Device plugin
+* CB-5504 Moving Telephony Logic out of Device
+
+### 0.2.7 (Jan 07, 2014)
+* CB-5737 Fix exception on close caused by left over telephony code from CB-5504
+
+### 0.2.8 (Feb 05, 2014)
+* Tizen support added

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/doc/index.md
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/doc/index.md
@@ -1,0 +1,213 @@
+<!---
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# org.apache.cordova.device
+
+This plugin defines a global `device` object, which describes the device's hardware and software.
+Although the object is in the global scope, it is not available until after the `deviceready` event.
+
+    document.addEventListener("deviceready", onDeviceReady, false);
+    function onDeviceReady() {
+        console.log(device.cordova);
+    }
+
+## Installation
+
+    cordova plugin add org.apache.cordova.device
+
+## Properties
+
+- device.cordova
+- device.model
+- device.name
+- device.platform
+- device.uuid
+- device.version
+
+## device.cordova
+
+Get the version of Cordova running on the device.
+
+### Supported Platforms
+
+- Amazon Fire OS
+- Android
+- BlackBerry 10
+- Firefox OS
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+## device.model
+
+The `device.model` returns the name of the device's model or
+product. The value is set by the device manufacturer and may be
+different across versions of the same product.
+
+### Supported Platforms
+
+- Android
+- BlackBerry 10
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+### Quick Example
+
+    // Android:    Nexus One       returns "Passion" (Nexus One code name)
+    //             Motorola Droid  returns "voles"
+    // BlackBerry: Torch 9800      returns "9800"
+    // iOS:     for the iPad Mini, returns iPad2,5; iPhone 5 is iPhone 5,1. See http://theiphonewiki.com/wiki/index.php?title=Models
+    //
+    var model = device.model;
+
+### Android Quirks
+
+- Gets the [product name](http://developer.android.com/reference/android/os/Build.html#PRODUCT) instead of the [model name](http://developer.android.com/reference/android/os/Build.html#MODEL), which is often the production code name. For example, the Nexus One returns `Passion`, and Motorola Droid returns `voles`.
+
+### Tizen Quirks
+
+- Returns the device model assigned by the vendor, for example, `TIZEN`
+
+### Windows Phone 7 and 8 Quirks
+
+- Returns the device model specified by the manufacturer. For example, the Samsung Focus returns `SGH-i917`.
+
+## device.name
+
+__WARNING__: `device.name` is deprecated as of version 2.3.0. Use `device.model` instead.
+
+## device.platform
+
+Get the device's operating system name.
+
+    var string = device.platform;
+
+### Supported Platforms
+
+- Android
+- BlackBerry 10
+- Firefox OS
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+### Quick Example
+
+    // Depending on the device, a few examples are:
+    //   - "Android"
+    //   - "BlackBerry 10"
+    //   - "iOS"
+    //   - "WinCE"
+    //   - "Tizen"
+    var devicePlatform = device.platform;
+
+### Windows Phone 7 Quirks
+
+Windows Phone 7 devices report the platform as `WinCE`.
+
+### Windows Phone 8 Quirks
+
+Windows Phone 8 devices report the platform as `Win32NT`.
+
+## device.uuid
+
+Get the device's Universally Unique Identifier ([UUID](http://en.wikipedia.org/wiki/Universally_Unique_Identifier)).
+
+    var string = device.uuid;
+
+### Description
+
+The details of how a UUID is generated are determined by the device manufacturer and are specific to the device's platform or model.
+
+### Supported Platforms
+
+- Android
+- BlackBerry 10
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+### Quick Example
+
+    // Android: Returns a random 64-bit integer (as a string, again!)
+    //          The integer is generated on the device's first boot
+    //
+    // BlackBerry: Returns the PIN number of the device
+    //             This is a nine-digit unique integer (as a string, though!)
+    //
+    // iPhone: (Paraphrased from the UIDevice Class documentation)
+    //         Returns a string of hash values created from multiple hardware identifies.
+    //         It is guaranteed to be unique for every device and can't be tied
+    //         to the user account.
+    // Windows Phone 7 : Returns a hash of device+current user,
+    // if the user is not defined, a guid is generated and will persist until the app is uninstalled
+    // Tizen: returns the device IMEI (International Mobile Equipment Identity or IMEI is a number
+    // unique to every GSM and UMTS mobile phone.
+    var deviceID = device.uuid;
+
+### iOS Quirk
+
+The `uuid` on iOS is not unique to a device, but varies for each
+application, for each installation.  It changes if you delete and
+re-install the app, and possibly also when you upgrade iOS, or even
+upgrade the app per version (apparent in iOS 5.1). The `uuid` is not
+a reliable value.
+
+### Windows Phone 7 and 8 Quirks
+
+The `uuid` for Windows Phone 7 requires the permission
+`ID_CAP_IDENTITY_DEVICE`.  Microsoft will likely deprecate this
+property soon.  If the capability is not available, the application
+generates a persistent guid that is maintained for the duration of the
+application's installation on the device.
+
+## device.version
+
+Get the operating system version.
+
+    var string = device.version;
+
+### Supported Platforms
+
+- Android 2.1+
+- BlackBerry 10
+- iOS
+- Tizen
+- Windows Phone 7 and 8
+- Windows 8
+
+### Quick Example
+
+    // Android:    Froyo OS would return "2.2"
+    //             Eclair OS would return "2.1", "2.0.1", or "2.0"
+    //             Version can also return update level "2.1-update1"
+    //
+    // BlackBerry: Torch 9800 using OS 6.0 would return "6.0.0.600"
+    //
+    // iPhone:     iOS 3.2 returns "3.2"
+    //
+    // Windows Phone 7: returns current OS version number, ex. on Mango returns 7.10.7720
+    // Tizen: returns "TIZEN_20120425_2"
+    var deviceVersion = device.version;
+

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/package.json
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/package.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.8",
+    "name": "org.apache.cordova.device",
+    "cordova_name": "Device",
+    "description": "Cordova Device Plugin",
+    "license": "Apache 2.0",
+    "repo": "https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git",
+    "issue": "https://issues.apache.org/jira/browse/CB/component/12320648",
+    "keywords": [
+        "cordova",
+        "device"
+    ],
+    "engines": []
+}

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/plugin.xml
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/plugin.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.apache.cordova.device"
+    version="0.2.8">
+    <name>Device</name>
+    <description>Cordova Device Plugin</description>
+    <license>Apache 2.0</license>
+    <keywords>cordova,device</keywords>
+    <repo>https://git-wip-us.apache.org/repos/asf/cordova-plugin-device.git</repo>
+    <issue>https://issues.apache.org/jira/browse/CB/component/12320648</issue>
+
+    <js-module src="www/device.js" name="device">
+        <clobbers target="device" />
+    </js-module>
+
+    <!-- firefoxos -->
+    <platform name="firefoxos">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="firefoxos-package" value="Device" />
+            </feature>
+        </config-file>
+
+        <js-module src="src/firefoxos/DeviceProxy.js" name="DeviceProxy">
+            <runs />
+        </js-module>
+    </platform>
+
+    <!-- tizen -->
+    <platform name="tizen">
+        <js-module src="src/tizen/DeviceProxy.js" name="DeviceProxy">
+            <runs />
+        </js-module>
+    </platform>
+
+    <!-- android -->
+    <platform name="android">
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="Device" >
+                <param name="android-package" value="org.apache.cordova.device.Device"/>
+            </feature>
+        </config-file>
+
+        <source-file src="src/android/Device.java" target-dir="src/org/apache/cordova/device" />
+    </platform>
+
+    <!-- amazon-fireos -->
+    <platform name="amazon-fireos">
+        <config-file target="res/xml/config.xml" parent="/*">
+            <feature name="Device" >
+                <param name="android-package" value="org.apache.cordova.device.Device"/>
+            </feature>
+        </config-file>
+
+        <source-file src="src/android/Device.java" target-dir="src/org/apache/cordova/device" />
+    </platform>
+    
+    <!-- ubuntu -->
+    <platform name="ubuntu">
+        <header-file src="src/ubuntu/device.h" />
+        <source-file src="src/ubuntu/device.cpp" />
+        <js-module src="src/ubuntu/device.js" name="DeviceProxy">
+            <merges target="device" />
+        </js-module>
+    </platform>
+
+    <!-- ios -->
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="ios-package" value="CDVDevice"/>
+            </feature>
+        </config-file>
+
+        <header-file src="src/ios/CDVDevice.h" />
+        <source-file src="src/ios/CDVDevice.m" />
+    </platform>
+
+    <!-- blackberry10 -->
+    <platform name="blackberry10">
+        <source-file src="src/blackberry10/index.js" target-dir="Device" />
+        <config-file target="www/config.xml" parent="/widget">
+            <feature name="Device" value="Device"/>
+        </config-file>
+        <config-file target="www/config.xml" parent="/widget/rim:permissions">
+            <rim:permit>read_device_identifying_information</rim:permit>
+        </config-file>
+    </platform>
+
+    <!-- wp7 -->
+    <platform name="wp7">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="wp-package" value="Device"/>
+            </feature>
+        </config-file>
+
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+            <Capability Name="ID_CAP_IDENTITY_DEVICE" />
+        </config-file>
+
+        <source-file src="src/wp/Device.cs" />
+    </platform>
+
+    <!-- wp8 -->
+    <platform name="wp8">
+        <config-file target="config.xml" parent="/*">
+            <feature name="Device">
+                <param name="wp-package" value="Device"/>
+            </feature>
+        </config-file>
+
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+            <Capability Name="ID_CAP_IDENTITY_DEVICE" />
+        </config-file>
+
+        <source-file src="src/wp/Device.cs" />
+    </platform>
+
+    <!-- windows8 -->
+    <platform name="windows8">
+        <js-module src="src/windows8/DeviceProxy.js" name="DeviceProxy">
+            <merges target="" />
+        </js-module>
+    </platform>
+
+</plugin>

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/android/Device.java
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/android/Device.java
@@ -1,0 +1,167 @@
+/*
+       Licensed to the Apache Software Foundation (ASF) under one
+       or more contributor license agreements.  See the NOTICE file
+       distributed with this work for additional information
+       regarding copyright ownership.  The ASF licenses this file
+       to you under the Apache License, Version 2.0 (the
+       "License"); you may not use this file except in compliance
+       with the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing,
+       software distributed under the License is distributed on an
+       "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+       KIND, either express or implied.  See the License for the
+       specific language governing permissions and limitations
+       under the License.
+*/
+package org.apache.cordova.device;
+
+import java.util.TimeZone;
+
+import org.apache.cordova.CordovaWebView;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.CordovaInterface;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import android.provider.Settings;
+
+public class Device extends CordovaPlugin {
+    public static final String TAG = "Device";
+
+    public static String cordovaVersion = "dev";              // Cordova version
+    public static String platform;                            // Device OS
+    public static String uuid;                                // Device UUID
+
+    private static final String ANDROID_PLATFORM = "Android";
+    private static final String AMAZON_PLATFORM = "amazon-fireos";
+    private static final String AMAZON_DEVICE = "Amazon";
+
+    /**
+     * Constructor.
+     */
+    public Device() {
+    }
+
+    /**
+     * Sets the context of the Command. This can then be used to do things like
+     * get file paths associated with the Activity.
+     *
+     * @param cordova The context of the main Activity.
+     * @param webView The CordovaWebView Cordova is running in.
+     */
+    public void initialize(CordovaInterface cordova, CordovaWebView webView) {
+        super.initialize(cordova, webView);
+        Device.uuid = getUuid();
+    }
+
+    /**
+     * Executes the request and returns PluginResult.
+     *
+     * @param action            The action to execute.
+     * @param args              JSONArry of arguments for the plugin.
+     * @param callbackContext   The callback id used when calling back into JavaScript.
+     * @return                  True if the action was valid, false if not.
+     */
+    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+        if (action.equals("getDeviceInfo")) {
+            JSONObject r = new JSONObject();
+            r.put("uuid", Device.uuid);
+            r.put("version", this.getOSVersion());
+            r.put("platform", this.getPlatform());
+            r.put("cordova", Device.cordovaVersion);
+            r.put("model", this.getModel());
+            callbackContext.success(r);
+        }
+        else {
+            return false;
+        }
+        return true;
+    }
+
+    //--------------------------------------------------------------------------
+    // LOCAL METHODS
+    //--------------------------------------------------------------------------
+
+    /**
+     * Get the OS name.
+     * 
+     * @return
+     */
+    public String getPlatform() {
+        String platform;
+        if (isAmazonDevice()) {
+            platform = AMAZON_PLATFORM;
+        } else {
+            platform = ANDROID_PLATFORM;
+        }
+        return platform;
+    }
+
+    /**
+     * Get the device's Universally Unique Identifier (UUID).
+     *
+     * @return
+     */
+    public String getUuid() {
+        String uuid = Settings.Secure.getString(this.cordova.getActivity().getContentResolver(), android.provider.Settings.Secure.ANDROID_ID);
+        return uuid;
+    }
+
+    /**
+     * Get the Cordova version.
+     *
+     * @return
+     */
+    public String getCordovaVersion() {
+        return Device.cordovaVersion;
+    }
+
+    public String getModel() {
+        String model = android.os.Build.MODEL;
+        return model;
+    }
+
+    public String getProductName() {
+        String productname = android.os.Build.PRODUCT;
+        return productname;
+    }
+
+    /**
+     * Get the OS version.
+     *
+     * @return
+     */
+    public String getOSVersion() {
+        String osversion = android.os.Build.VERSION.RELEASE;
+        return osversion;
+    }
+
+    public String getSDKVersion() {
+        @SuppressWarnings("deprecation")
+        String sdkversion = android.os.Build.VERSION.SDK;
+        return sdkversion;
+    }
+
+    public String getTimeZoneID() {
+        TimeZone tz = TimeZone.getDefault();
+        return (tz.getID());
+    }
+
+    /**
+     * Function to check if the device is manufactured by Amazon
+     * 
+     * @return
+     */
+    public boolean isAmazonDevice() {
+        if (android.os.Build.MANUFACTURER.equals(AMAZON_DEVICE)) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/blackberry10/index.js
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/blackberry10/index.js
@@ -1,0 +1,69 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+function getModelName () {
+    var modelName = window.qnx.webplatform.device.modelName;
+    //Pre 10.2 (meaning Z10 or Q10)
+    if (typeof modelName === "undefined") {
+        if (window.screen.height === 720 && window.screen.width === 720) {
+            if ( window.matchMedia("(-blackberry-display-technology: -blackberry-display-oled)").matches) {
+                modelName = "Q10";
+            } else {
+                modelName = "Q5";
+            }
+        } else if ((window.screen.height === 1280 && window.screen.width === 768) ||
+                   (window.screen.height === 768 && window.screen.width === 1280)) {
+            modelName = "Z10";
+        } else {
+            modelName = window.qnx.webplatform.deviceName;
+        }
+    }
+
+    return modelName;
+}
+
+function getUUID () {
+    var uuid = "";
+    try {
+        //Must surround by try catch because this will throw if the app is missing permissions
+        uuid = window.qnx.webplatform.device.devicePin;
+    } catch (e) {
+        //DO Nothing
+    }
+    return uuid;
+}
+
+module.exports = {
+    getDeviceInfo: function (success, fail, args, env) {
+        var result = new PluginResult(args, env),
+            modelName = getModelName(),
+            uuid = getUUID(),
+            info = {
+                platform: "blackberry10",
+                version: window.qnx.webplatform.device.scmBundle,
+                model: modelName,
+                uuid: uuid,
+                cordova: "dev"
+            };
+
+        result.ok(info);
+    }
+};

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/firefoxos/DeviceProxy.js
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/firefoxos/DeviceProxy.js
@@ -1,0 +1,39 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var firefoxos = require('cordova/platform');
+var cordova = require('cordova');
+
+module.exports = {
+    getDeviceInfo: function(success, error) {
+        setTimeout(function () {
+            success({
+                cordova: firefoxos.cordovaVersion,
+                platform: 'firefoxos',
+                model: null,
+                version: null,
+                uuid: null
+            });
+        }, 0);
+    }
+};
+
+require("cordova/firefoxos/commandProxy").add("Device", module.exports);

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/ios/CDVDevice.h
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/ios/CDVDevice.h
@@ -1,0 +1,30 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <UIKit/UIKit.h>
+#import <Cordova/CDVPlugin.h>
+
+@interface CDVDevice : CDVPlugin
+{}
+
++ (NSString*)cordovaVersion;
+
+- (void)getDeviceInfo:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/ios/CDVDevice.m
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/ios/CDVDevice.m
@@ -1,0 +1,90 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+#import <Cordova/CDV.h>
+#import "CDVDevice.h"
+
+@implementation UIDevice (ModelVersion)
+
+- (NSString*)modelVersion
+{
+    size_t size;
+
+    sysctlbyname("hw.machine", NULL, &size, NULL, 0);
+    char* machine = malloc(size);
+    sysctlbyname("hw.machine", machine, &size, NULL, 0);
+    NSString* platform = [NSString stringWithUTF8String:machine];
+    free(machine);
+
+    return platform;
+}
+
+@end
+
+@interface CDVDevice () {}
+@end
+
+@implementation CDVDevice
+
+- (void)getDeviceInfo:(CDVInvokedUrlCommand*)command
+{
+    NSDictionary* deviceProperties = [self deviceProperties];
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:deviceProperties];
+
+    /* Settings.plist
+     * Read the optional Settings.plist file and push these user-defined settings down into the web application.
+     * This can be useful for supplying build-time configuration variables down to the app to change its behavior,
+     * such as specifying Full / Lite version, or localization (English vs German, for instance).
+     */
+    // TODO: turn this into an iOS only plugin
+    NSDictionary* temp = [CDVViewController getBundlePlist:@"Settings"];
+
+    if ([temp respondsToSelector:@selector(JSONString)]) {
+        NSLog(@"Deprecation warning: window.Setting will be removed Aug 2013. Refer to https://issues.apache.org/jira/browse/CB-2433");
+        NSString* js = [NSString stringWithFormat:@"window.Settings = %@;", [temp JSONString]];
+        [self.commandDelegate evalJs:js];
+    }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+}
+
+- (NSDictionary*)deviceProperties
+{
+    UIDevice* device = [UIDevice currentDevice];
+    NSMutableDictionary* devProps = [NSMutableDictionary dictionaryWithCapacity:4];
+
+    [devProps setObject:[device modelVersion] forKey:@"model"];
+    [devProps setObject:@"iOS" forKey:@"platform"];
+    [devProps setObject:[device systemVersion] forKey:@"version"];
+    [devProps setObject:[device uniqueAppInstanceIdentifier] forKey:@"uuid"];
+    [devProps setObject:[[self class] cordovaVersion] forKey:@"cordova"];
+
+    NSDictionary* devReturn = [NSDictionary dictionaryWithDictionary:devProps];
+    return devReturn;
+}
+
++ (NSString*)cordovaVersion
+{
+    return CDV_VERSION;
+}
+
+@end

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/tizen/DeviceProxy.js
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/tizen/DeviceProxy.js
@@ -1,0 +1,39 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var tizen = require('cordova/platform');
+var cordova = require('cordova');
+
+module.exports = {
+    getDeviceInfo: function(success, error) {
+        setTimeout(function () {
+            success({
+                cordova: tizen.cordovaVersion,
+                platform: 'tizen',
+                model: null,
+                version: null,
+                uuid: null
+            });
+        }, 0);
+    }
+};
+
+require("cordova/tizen/commandProxy").add("Device", module.exports);

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/ubuntu/device.cpp
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/ubuntu/device.cpp
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2011 Wolfgang Koller - http://www.gofg.at/
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#include <QDeviceInfo>
+#include <QtSystemInfo>
+
+#include"device.h"
+
+#define CORDOVA "3.0.0"
+
+Device::Device(Cordova *cordova) : CPlugin(cordova) {
+}
+
+static QString getOSName() {
+#ifdef Q_OS_SYMBIAN
+    QString platform = "Symbian";
+#endif
+#ifdef Q_OS_WIN
+    QString platform = "Windows";
+#endif
+#ifdef Q_OS_WINCE
+    QString platform = "Windows CE";
+#endif
+#ifdef Q_OS_LINUX
+    QString platform = "Linux";
+#endif
+    return platform;
+}
+
+void Device::getInfo(int scId, int ecId) {
+    Q_UNUSED(ecId)
+
+    QDeviceInfo systemDeviceInfo;
+    QDeviceInfo systemInfo;
+
+    QString platform = getOSName();
+
+    QString uuid = systemDeviceInfo.uniqueDeviceID();
+    if (uuid.isEmpty()) {
+        QString deviceDescription = systemInfo.imei(0) + ";" + systemInfo.manufacturer() + ";" + systemInfo.model() + ";" + systemInfo.productName() + ";" + platform;
+        QString user = qgetenv("USER");
+        if (user.isEmpty()) {
+            user = qgetenv("USERNAME");
+            if (user.isEmpty())
+                user = QDir::homePath();
+        }
+        uuid = QString(QCryptographicHash::hash((deviceDescription + ";" + user).toUtf8(), QCryptographicHash::Md5).toHex());
+    }
+
+    this->cb(scId, systemDeviceInfo.model(), CORDOVA, platform, uuid, systemInfo.version(QDeviceInfo::Os));
+}

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/ubuntu/device.h
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/ubuntu/device.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2011 Wolfgang Koller - http://www.gofg.at/
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#ifndef DEVICE_H_FDSAFAS
+#define DEVICE_H_FDSAFAS
+
+#include <QtCore>
+
+#include <cplugin.h>
+
+class Device: public CPlugin {
+    Q_OBJECT
+public:
+    explicit Device(Cordova *cordova);
+
+    virtual const QString fullName() override {
+        return Device::fullID();
+    }
+
+    virtual const QString shortName() override {
+        return "Device";
+    }
+
+    static const QString fullID() {
+        return "com.cordova.Device";
+    }
+
+signals:
+
+public slots:
+    void getInfo(int scId, int ecId);
+};
+
+#endif

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/ubuntu/device.js
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/ubuntu/device.js
@@ -1,0 +1,34 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var cordova = require('cordova');
+var exec = require('cordova/exec');
+
+module.exports = {
+    getInfo:function(win,fail,args) {
+        Cordova.exec(function (model, cordova, platform, uuid, version) {
+            win({name: name, model: model, cordova: cordova,
+                 platform: platform, uuid: uuid, version: version});
+        }, null, "com.cordova.Device", "getInfo", []);
+    }
+};
+
+require("cordova/exec/proxy").add("Device", module.exports);

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/windows8/DeviceProxy.js
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/windows8/DeviceProxy.js
@@ -1,0 +1,50 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+
+var cordova = require('cordova');
+var utils = require('cordova/utils');
+
+module.exports = {
+
+    getDeviceInfo:function(win,fail,args) {
+
+        // deviceId aka uuid, stored in Windows.Storage.ApplicationData.current.localSettings.values.deviceId
+        var deviceId;
+
+        var localSettings = Windows.Storage.ApplicationData.current.localSettings;
+
+        if (localSettings.values.deviceId) {
+            deviceId = localSettings.values.deviceId;
+        }
+        else {
+            deviceId = localSettings.values.deviceId = utils.createUUID();
+        }
+
+        setTimeout(function () {
+            win({ platform: "windows8", version: "8", uuid: deviceId, cordova: '0.0.0', model: window.clientInformation.platform });
+        }, 0);
+    }
+
+};
+
+require("cordova/windows8/commandProxy").add("Device", module.exports);
+

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/src/wp/Device.cs
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/src/wp/Device.cs
@@ -1,0 +1,135 @@
+﻿/*  
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+	
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+using System;
+using System.Net;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Documents;
+using System.Windows.Ink;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Shapes;
+using Microsoft.Phone.Info;
+using System.IO.IsolatedStorage;
+using System.Windows.Resources;
+using System.IO;
+using System.Diagnostics;
+
+namespace WPCordovaClassLib.Cordova.Commands
+{
+    public class Device : BaseCommand
+    {
+        public void getDeviceInfo(string notused)
+        {
+
+            string res = String.Format("\"name\":\"{0}\",\"cordova\":\"{1}\",\"platform\":\"{2}\",\"uuid\":\"{3}\",\"version\":\"{4}\",\"model\":\"{5}\"",
+                                        this.name,
+                                        this.cordova,
+                                        this.platform,
+                                        this.uuid,
+                                        this.version,
+                                        this.model);
+
+
+
+            res = "{" + res + "}";
+            //Debug.WriteLine("Result::" + res);
+            DispatchCommandResult(new PluginResult(PluginResult.Status.OK, res));
+        }
+
+        public string model
+        {
+            get
+            {
+                return DeviceStatus.DeviceName;
+                //return String.Format("{0},{1},{2}", DeviceStatus.DeviceManufacturer, DeviceStatus.DeviceHardwareVersion, DeviceStatus.DeviceFirmwareVersion); 
+            }
+        }
+
+        public string name
+        {
+            get
+            {
+                return DeviceStatus.DeviceName;
+                
+            }
+        }
+
+        public string cordova
+        {
+            get
+            {
+                // TODO: should be able to dynamically read the Cordova version from somewhere...
+                return "3.0.0";
+            }
+        }
+
+        public string platform
+        {
+            get
+            {
+                return Environment.OSVersion.Platform.ToString();
+            }
+        }
+
+        public string uuid
+        {
+            get
+            {
+                string returnVal = "";
+                object id;
+                UserExtendedProperties.TryGetValue("ANID", out id);
+
+                if (id != null)
+                {
+                    returnVal = id.ToString().Substring(2, 32);
+                }
+                else
+                {
+                    returnVal = "???unknown???";
+
+                    using (IsolatedStorageFile appStorage = IsolatedStorageFile.GetUserStoreForApplication())
+                    {
+                        try
+                        {
+                            IsolatedStorageFileStream fileStream = new IsolatedStorageFileStream("DeviceID.txt", FileMode.Open, FileAccess.Read, appStorage);
+
+                            using (StreamReader reader = new StreamReader(fileStream))
+                            {
+                                returnVal = reader.ReadLine();
+                            }
+                        }
+                        catch (Exception /*ex*/)
+                        {
+
+                        }
+                    }
+                }
+
+                return returnVal;
+            }
+        }
+
+        public string version
+        {
+            get
+            {
+                return Environment.OSVersion.Version.ToString();
+            }
+        }
+
+    }
+}

--- a/kitchensink-cordova/plugins/org.apache.cordova.device/www/device.js
+++ b/kitchensink-cordova/plugins/org.apache.cordova.device/www/device.js
@@ -1,0 +1,77 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    channel = require('cordova/channel'),
+    utils = require('cordova/utils'),
+    exec = require('cordova/exec'),
+    cordova = require('cordova');
+
+channel.createSticky('onCordovaInfoReady');
+// Tell cordova channel to wait on the CordovaInfoReady event
+channel.waitForInitialization('onCordovaInfoReady');
+
+/**
+ * This represents the mobile device, and provides properties for inspecting the model, version, UUID of the
+ * phone, etc.
+ * @constructor
+ */
+function Device() {
+    this.available = false;
+    this.platform = null;
+    this.version = null;
+    this.uuid = null;
+    this.cordova = null;
+    this.model = null;
+
+    var me = this;
+
+    channel.onCordovaReady.subscribe(function() {
+        me.getInfo(function(info) {
+            //ignoring info.cordova returning from native, we should use value from cordova.version defined in cordova.js
+            //TODO: CB-5105 native implementations should not return info.cordova
+            var buildLabel = cordova.version;
+            me.available = true;
+            me.platform = info.platform;
+            me.version = info.version;
+            me.uuid = info.uuid;
+            me.cordova = buildLabel;
+            me.model = info.model;
+            channel.onCordovaInfoReady.fire();
+        },function(e) {
+            me.available = false;
+            utils.alert("[ERROR] Error initializing Cordova: " + e);
+        });
+    });
+}
+
+/**
+ * Get device info
+ *
+ * @param {Function} successCallback The function to call when the heading data is available
+ * @param {Function} errorCallback The function to call when there is an error getting the heading data. (OPTIONAL)
+ */
+Device.prototype.getInfo = function(successCallback, errorCallback) {
+    argscheck.checkArgs('fF', 'Device.getInfo', arguments);
+    exec(successCallback, errorCallback, "Device", "getDeviceInfo", []);
+};
+
+module.exports = new Device();

--- a/kitchensink-cordova/plugins/org.apache.cordova.statusbar/README.md
+++ b/kitchensink-cordova/plugins/org.apache.cordova.statusbar/README.md
@@ -1,0 +1,186 @@
+StatusBar
+======
+
+> The `StatusBar` object provides some functions to customize the iOS StatusBar.
+
+The plugin reads the __StatusBarOverlaysWebView__ (boolean, defaults to true) and __StatusBarBackgroundColor__ (color hex string, defaults to #000000) values from config.xml.
+ 
+Methods
+-------
+
+- StatusBar.overlaysWebView
+- StatusBar.styleDefault
+- StatusBar.styleLightContent
+- StatusBar.styleBlackTranslucent
+- StatusBar.styleBlackOpaque
+- StatusBar.backgroundColorByName
+- StatusBar.backgroundColorByHexString
+- StatusBar.hide
+- StatusBar.show
+
+Properties
+--------
+
+- StatusBar.isVisible
+
+Permissions
+-----------
+
+#### config.xml
+
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+
+StatusBar.overlaysWebView
+=================
+
+On iOS 7, make the statusbar overlay or not overlay the WebView.
+
+    StatusBar.overlaysWebView(true);
+
+Description
+-----------
+
+On iOS 7, set to false to make the statusbar appear like iOS 6. Set the style and background color to suit using the other functions.
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+Quick Example
+-------------
+
+    StatusBar.overlaysWebView(true);
+    StatusBar.overlaysWebView(false);
+
+StatusBar.styleDefault
+=================
+
+Use the default statusbar (dark text, for light backgrounds).
+
+    StatusBar.styleDefault();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.styleLightContent
+=================
+
+Use the lightContent statusbar (light text, for dark backgrounds).
+
+    StatusBar.styleLightContent();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.styleBlackTranslucent
+=================
+
+Use the blackTranslucent statusbar (light text, for dark backgrounds).
+
+    StatusBar.styleBlackTranslucent();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.styleBlackOpaque
+=================
+
+Use the blackOpaque statusbar (light text, for dark backgrounds).
+
+    StatusBar.styleBlackOpaque();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+
+StatusBar.backgroundColorByName
+=================
+
+On iOS 7, when you set StatusBar.statusBarOverlaysWebView to false, you can set the background color of the statusbar by color name.
+
+    StatusBar.backgroundColorByName("red");
+
+Supported color names are:
+
+    black, darkGray, lightGray, white, gray, red, green, blue, cyan, yellow, magenta, orange, purple, brown, clear
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.backgroundColorByHexString
+=================
+
+On iOS 7, when you set StatusBar.statusBarOverlaysWebView to false, you can set the background color of the statusbar by a hex string (#RRGGBB).
+
+    StatusBar.backgroundColorByHexString("#C0C0C0");
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.hide
+=================
+
+Hide the statusbar.
+
+    StatusBar.hide();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+StatusBar.show
+=================
+
+Shows the statusbar.
+
+    StatusBar.show();
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+
+StatusBar.isVisible
+=================
+
+Read this property to see if the statusbar is visible or not.
+
+    if (StatusBar.isVisible) {
+    	// do something
+    }
+
+
+Supported Platforms
+-------------------
+
+- iOS
+
+
+
+    

--- a/kitchensink-cordova/plugins/org.apache.cordova.statusbar/package.json
+++ b/kitchensink-cordova/plugins/org.apache.cordova.statusbar/package.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.1.3",
+    "name": "org.apache.cordova.statusbar",
+    "cordova_name": "StatusBar",
+    "description": "Cordova StatusBar Plugin",
+    "license": "Apache 2.0",
+    "keywords": [
+        "cordova",
+        "statusbar"
+    ],
+    "engines": [
+        {
+            "name": "cordova",
+            "version": ">=3.0.0"
+        }
+    ]
+}

--- a/kitchensink-cordova/plugins/org.apache.cordova.statusbar/plugin.xml
+++ b/kitchensink-cordova/plugins/org.apache.cordova.statusbar/plugin.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="org.apache.cordova.statusbar"
+    version="0.1.3">
+    <name>StatusBar</name>
+    <description>Cordova StatusBar Plugin</description>
+    <license>Apache 2.0</license>
+    <keywords>cordova,statusbar</keywords>
+
+	<engines>
+		<engine name="cordova" version=">=3.0.0" />
+	</engines>
+
+    <js-module src="www/statusbar.js" name="statusbar">
+    	<clobbers target="window.StatusBar" />
+    </js-module>
+
+    <!-- ios -->
+    <platform name="ios">
+        <config-file target="config.xml" parent="/*">
+            <feature name="StatusBar">
+                <param name="ios-package" value="CDVStatusBar" onload="true" />
+            </feature>
+            <preference name="StatusBarOverlaysWebView" value="true" />
+            <preference name="StatusBarBackgroundColor" value="#000000" />
+        </config-file>
+        
+        <header-file src="src/ios/CDVStatusBar.h" />
+        <source-file src="src/ios/CDVStatusBar.m" />
+        
+    </platform>
+
+</plugin>

--- a/kitchensink-cordova/plugins/org.apache.cordova.statusbar/src/ios/CDVStatusBar.h
+++ b/kitchensink-cordova/plugins/org.apache.cordova.statusbar/src/ios/CDVStatusBar.h
@@ -1,0 +1,51 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+#import <Cordova/CDVPlugin.h>
+#import <Cordova/CDVInvokedUrlCommand.h>
+
+@interface CDVStatusBar : CDVPlugin {
+    @protected
+    BOOL _statusBarOverlaysWebView;
+    @protected
+    UIView* _statusBarBackgroundView;
+    @protected
+    BOOL _uiviewControllerBasedStatusBarAppearance;
+    @protected
+    UIColor* _statusBarBackgroundColor;
+}
+
+@property (atomic, assign) BOOL statusBarOverlaysWebView;
+
+- (void) overlaysWebView:(CDVInvokedUrlCommand*)command;
+
+- (void) styleDefault:(CDVInvokedUrlCommand*)command;
+- (void) styleLightContent:(CDVInvokedUrlCommand*)command;
+- (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command;
+- (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command;
+
+- (void) backgroundColorByName:(CDVInvokedUrlCommand*)command;
+- (void) backgroundColorByHexString:(CDVInvokedUrlCommand*)command;
+
+- (void) hide:(CDVInvokedUrlCommand*)command;
+- (void) show:(CDVInvokedUrlCommand*)command;
+    
+- (void) _ready:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/kitchensink-cordova/plugins/org.apache.cordova.statusbar/src/ios/CDVStatusBar.m
+++ b/kitchensink-cordova/plugins/org.apache.cordova.statusbar/src/ios/CDVStatusBar.m
@@ -1,0 +1,401 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ */
+
+/* 
+ NOTE: plugman/cordova cli should have already installed this,
+ but you need the value UIViewControllerBasedStatusBarAppearance
+ in your Info.plist as well to set the styles in iOS 7
+ */
+
+#import "CDVStatusBar.h"
+#import <objc/runtime.h>
+#import <Cordova/CDVViewController.h>
+
+static const void *kHideStatusBar = &kHideStatusBar;
+static const void *kStatusBarStyle = &kStatusBarStyle;
+
+@interface CDVViewController (StatusBar)
+
+@property (nonatomic, retain) id sb_hideStatusBar;
+@property (nonatomic, retain) id sb_statusBarStyle;
+    
+@end
+
+@implementation CDVViewController (StatusBar)
+
+@dynamic sb_hideStatusBar;
+@dynamic sb_statusBarStyle;
+    
+- (id)sb_hideStatusBar {
+    return objc_getAssociatedObject(self, kHideStatusBar);
+}
+    
+- (void)setSb_hideStatusBar:(id)newHideStatusBar {
+    objc_setAssociatedObject(self, kHideStatusBar, newHideStatusBar, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+
+- (id)sb_statusBarStyle {
+    return objc_getAssociatedObject(self, kStatusBarStyle);
+}
+    
+- (void)setSb_statusBarStyle:(id)newStatusBarStyle {
+    objc_setAssociatedObject(self, kStatusBarStyle, newStatusBarStyle, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+}
+    
+- (BOOL) prefersStatusBarHidden {
+    return [self.sb_hideStatusBar boolValue];
+}
+    
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+    return (UIStatusBarStyle)[self.sb_statusBarStyle intValue];
+}
+    
+@end
+
+
+@implementation CDVStatusBar
+
+- (id)settingForKey:(NSString*)key
+{
+    return [self.commandDelegate.settings objectForKey:[key lowercaseString]];
+}
+
+- (void)observeValueForKeyPath:(NSString*)keyPath ofObject:(id)object change:(NSDictionary*)change context:(void*)context
+{
+    if ([keyPath isEqual:@"statusBarHidden"]) {
+        NSNumber* newValue = [change objectForKey:NSKeyValueChangeNewKey];
+        BOOL boolValue = [newValue boolValue];
+
+        [self.commandDelegate evalJs:[NSString stringWithFormat:@"StatusBar.isVisible = %@;", boolValue? @"false" : @"true" ]];
+    }
+}
+
+- (void)pluginInitialize
+{
+    BOOL isiOS7 = (IsAtLeastiOSVersion(@"7.0"));
+                   
+    // init
+    NSNumber* uiviewControllerBasedStatusBarAppearance = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"];
+    _uiviewControllerBasedStatusBarAppearance = (uiviewControllerBasedStatusBarAppearance == nil || [uiviewControllerBasedStatusBarAppearance boolValue]) && isiOS7;
+    
+    // observe the statusBarHidden property
+    [[UIApplication sharedApplication] addObserver:self forKeyPath:@"statusBarHidden" options:NSKeyValueObservingOptionNew context:NULL];
+    
+    _statusBarOverlaysWebView = YES; // default
+    
+    [self initializeStatusBarBackgroundView];
+    
+    [self styleLightContent:nil]; // match default backgroundColor of #000000
+    self.viewController.view.autoresizesSubviews = YES;
+    
+    NSString* setting;
+    
+    setting  = @"StatusBarOverlaysWebView";
+    if ([self settingForKey:setting]) {
+        self.statusBarOverlaysWebView = [(NSNumber*)[self settingForKey:setting] boolValue];
+    }
+
+    setting  = @"StatusBarBackgroundColor";
+    if ([self settingForKey:setting]) {
+        [self _backgroundColorByHexString:[self settingForKey:setting]];
+    }
+}
+
+- (void) _ready:(CDVInvokedUrlCommand*)command
+{
+    // set the initial value
+    [self.commandDelegate evalJs:[NSString stringWithFormat:@"StatusBar.isVisible = %@;", [UIApplication sharedApplication].statusBarHidden? @"false" : @"true" ]];
+}
+
+- (void) initializeStatusBarBackgroundView 
+{
+    CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+    if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+        // swap width and height. set origin to zero
+        statusBarFrame = CGRectMake(0, 0, statusBarFrame.size.height, statusBarFrame.size.width);
+    }
+
+    _statusBarBackgroundView = [[UIView alloc] initWithFrame:statusBarFrame];
+    _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
+    _statusBarBackgroundView.autoresizingMask = (UIViewAutoresizingFlexibleWidth  | UIViewAutoresizingFlexibleBottomMargin);
+    _statusBarBackgroundView.autoresizesSubviews = YES;
+}
+
+- (void) setStatusBarOverlaysWebView:(BOOL)statusBarOverlaysWebView
+{
+    // we only care about the latest iOS version or a change in setting
+    if (!IsAtLeastiOSVersion(@"7.0") || statusBarOverlaysWebView == _statusBarOverlaysWebView) {
+        return;
+    }
+
+    CGRect bounds = [[UIScreen mainScreen] bounds];
+    
+    if (statusBarOverlaysWebView) {
+        
+        [_statusBarBackgroundView removeFromSuperview];
+        self.webView.frame = bounds;
+
+    } else {
+
+        CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+
+        [self initializeStatusBarBackgroundView];
+
+        CGRect frame = self.webView.frame;
+
+        if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+            frame.origin.y = statusBarFrame.size.width;
+            frame.size.height -= statusBarFrame.size.width;
+        } else {
+            frame.origin.y = statusBarFrame.size.height;
+            frame.size.height -= statusBarFrame.size.height;
+        }
+        
+        self.webView.frame = frame;
+        [self.webView.superview addSubview:_statusBarBackgroundView];
+    }
+    
+    _statusBarOverlaysWebView = statusBarOverlaysWebView;
+}
+
+- (BOOL) statusBarOverlaysWebView
+{
+    return _statusBarOverlaysWebView;
+}
+
+- (void) overlaysWebView:(CDVInvokedUrlCommand*)command
+{
+    id value = [command.arguments objectAtIndex:0];
+    if (!([value isKindOfClass:[NSNumber class]])) {
+        value = [NSNumber numberWithBool:YES];
+    }
+    
+    self.statusBarOverlaysWebView = [value boolValue];
+}
+
+- (void) refreshStatusBarAppearance
+{
+    SEL sel = NSSelectorFromString(@"setNeedsStatusBarAppearanceUpdate");
+    if ([self.viewController respondsToSelector:sel]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        [self.viewController performSelector:sel withObject:nil];
+#pragma clang diagnostic pop
+    }
+}
+    
+- (void) setStyleForStatusBar:(UIStatusBarStyle)style
+{
+    if (_uiviewControllerBasedStatusBarAppearance) {
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        vc.sb_statusBarStyle = [NSNumber numberWithInt:style];
+        [self refreshStatusBarAppearance];
+        
+    } else {
+        [[UIApplication sharedApplication] setStatusBarStyle:style];
+    }
+}
+    
+- (void) setStatusBarStyle:(NSString*)statusBarStyle
+{
+    // default, lightContent, blackTranslucent, blackOpaque
+    NSString* lcStatusBarStyle = [statusBarStyle lowercaseString];
+    
+    if ([lcStatusBarStyle isEqualToString:@"default"]) {
+        [self styleDefault:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"lightcontent"]) {
+        [self styleLightContent:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"blacktranslucent"]) {
+        [self styleBlackTranslucent:nil];
+    } else if ([lcStatusBarStyle isEqualToString:@"blackopaque"]) {
+        [self styleBlackOpaque:nil];
+    }
+}
+
+- (void) styleDefault:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleDefault];
+}
+
+- (void) styleLightContent:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleLightContent];
+}
+
+- (void) styleBlackTranslucent:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleBlackTranslucent];
+}
+
+- (void) styleBlackOpaque:(CDVInvokedUrlCommand*)command
+{
+    [self setStyleForStatusBar:UIStatusBarStyleBlackOpaque];
+}
+
+- (void) backgroundColorByName:(CDVInvokedUrlCommand*)command
+{
+    id value = [command.arguments objectAtIndex:0];
+    if (!([value isKindOfClass:[NSString class]])) {
+        value = @"black";
+    }
+    
+    SEL selector = NSSelectorFromString([value stringByAppendingString:@"Color"]);
+    if ([UIColor respondsToSelector:selector]) {
+        _statusBarBackgroundView.backgroundColor = [UIColor performSelector:selector];
+    }
+}
+
+- (void) _backgroundColorByHexString:(NSString*)hexString
+{
+    unsigned int rgbValue = 0;
+    NSScanner* scanner = [NSScanner scannerWithString:hexString];
+    [scanner setScanLocation:1];
+    [scanner scanHexInt:&rgbValue];
+    
+    _statusBarBackgroundColor = [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+    _statusBarBackgroundView.backgroundColor = _statusBarBackgroundColor;
+}
+
+- (void) backgroundColorByHexString:(CDVInvokedUrlCommand*)command
+{
+    NSString* value = [command.arguments objectAtIndex:0];
+    if (!([value isKindOfClass:[NSString class]])) {
+        value = @"#000000";
+    }
+    
+    if (![value hasPrefix:@"#"] || [value length] < 7) {
+        return;
+    }
+    
+    [self _backgroundColorByHexString:value];
+}
+
+- (void) hideStatusBar
+{
+    if (_uiviewControllerBasedStatusBarAppearance) {
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        vc.sb_hideStatusBar = [NSNumber numberWithBool:YES];
+        [self refreshStatusBarAppearance];
+
+    } else {
+        UIApplication* app = [UIApplication sharedApplication];
+        [app setStatusBarHidden:YES];
+    }
+}
+    
+- (void) hide:(CDVInvokedUrlCommand*)command
+{
+    UIApplication* app = [UIApplication sharedApplication];
+    
+    if (!app.isStatusBarHidden)
+    {
+        self.viewController.wantsFullScreenLayout = YES;
+        CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+        
+        [self hideStatusBar];
+
+        if (IsAtLeastiOSVersion(@"7.0")) {
+            [_statusBarBackgroundView removeFromSuperview];
+        }
+        
+        CGRect frame = self.webView.frame;
+        frame.origin.y = 0;
+        
+        if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+            frame.size.height += statusBarFrame.size.width;
+        } else {
+            frame.size.height += statusBarFrame.size.height;
+        }
+        
+        self.webView.frame = frame;
+        _statusBarBackgroundView.hidden = YES;
+    }
+}
+    
+- (void) showStatusBar
+{
+    if (_uiviewControllerBasedStatusBarAppearance) {
+        CDVViewController* vc = (CDVViewController*)self.viewController;
+        vc.sb_hideStatusBar = [NSNumber numberWithBool:NO];
+        [self refreshStatusBarAppearance];
+
+    } else {
+        UIApplication* app = [UIApplication sharedApplication];
+        [app setStatusBarHidden:NO];
+    }
+}
+    
+- (void) show:(CDVInvokedUrlCommand*)command
+{
+    UIApplication* app = [UIApplication sharedApplication];
+    
+    if (app.isStatusBarHidden)
+    {
+        BOOL isIOS7 = (IsAtLeastiOSVersion(@"7.0"));
+        self.viewController.wantsFullScreenLayout = isIOS7;
+        
+        [self showStatusBar];
+        
+        if (isIOS7) {
+            CGRect frame = self.webView.frame;
+            self.viewController.view.frame = [[UIScreen mainScreen] bounds];
+            
+            CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
+            
+            if (!self.statusBarOverlaysWebView) {
+                
+                // there is a possibility that when the statusbar was hidden, it was in a different orientation
+                // from the current one. Therefore we need to expand the statusBarBackgroundView as well to the
+                // statusBar's current size
+                CGRect sbBgFrame = _statusBarBackgroundView.frame;
+                
+                if (UIDeviceOrientationIsLandscape(self.viewController.interfaceOrientation)) {
+                    frame.origin.y = statusBarFrame.size.width;
+                    frame.size.height -= statusBarFrame.size.width;
+                    sbBgFrame.size = CGSizeMake(statusBarFrame.size.height, statusBarFrame.size.width);
+                } else {
+                    frame.origin.y = statusBarFrame.size.height;
+                    frame.size.height -= statusBarFrame.size.height;
+                    sbBgFrame.size = statusBarFrame.size;
+                }
+                
+                _statusBarBackgroundView.frame = sbBgFrame;
+                [self.webView.superview addSubview:_statusBarBackgroundView];
+            }
+
+            self.webView.frame = frame;
+            
+        } else {
+            
+            CGRect bounds = [[UIScreen mainScreen] applicationFrame];
+            self.viewController.view.frame = bounds;
+        }
+        
+        _statusBarBackgroundView.hidden = NO;
+    }
+}
+
+- (void) dealloc
+{
+    [[UIApplication sharedApplication] removeObserver:self forKeyPath:@"statusBarHidden"];
+}
+
+
+@end

--- a/kitchensink-cordova/plugins/org.apache.cordova.statusbar/www/statusbar.js
+++ b/kitchensink-cordova/plugins/org.apache.cordova.statusbar/www/statusbar.js
@@ -1,0 +1,70 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+*/
+
+var argscheck = require('cordova/argscheck'),
+    utils = require('cordova/utils'),
+    exec = require('cordova/exec');
+
+// prime it
+exec(null, null, "StatusBar", "_ready", []);
+
+var StatusBar = function() {
+};
+
+StatusBar.overlaysWebView = function(doOverlay) {
+    exec(null, null, "StatusBar", "overlaysWebView", [doOverlay]);
+};
+
+StatusBar.styleDefault = function() {
+    exec(null, null, "StatusBar", "styleDefault", []);
+};
+
+StatusBar.styleLightContent = function() {
+    exec(null, null, "StatusBar", "styleLightContent", []);
+};
+
+StatusBar.styleBlackTranslucent = function() {
+    exec(null, null, "StatusBar", "styleBlackTranslucent", []);
+};
+
+StatusBar.styleBlackOpaque = function() {
+    exec(null, null, "StatusBar", "styleBlackOpaque", []);
+};
+
+StatusBar.backgroundColorByName = function(colorname) {
+    exec(null, null, "StatusBar", "backgroundColorByName", [colorname]);
+}
+
+StatusBar.backgroundColorByHexString = function(hexString) {
+    exec(null, null, "StatusBar", "backgroundColorByHexString", [hexString]);
+}
+
+StatusBar.hide = function() {
+    exec(null, null, "StatusBar", "hide", []);
+}
+
+StatusBar.show = function() {
+    exec(null, null, "StatusBar", "show", []);
+}
+
+StatusBar.isVisible = true;
+
+module.exports = StatusBar;

--- a/kitchensink-cordova/www/config.xml
+++ b/kitchensink-cordova/www/config.xml
@@ -9,7 +9,7 @@
 		event.
 	</description>
 
-	<author href="http://aerogear.org/" email="aerogear-dev@lists.jboss.org">
+	<author href="http://jboss.org/jdf" email="jdf-users@lists.jboss.org">
 		JBoss by Red Hat
 	</author>
 
@@ -26,6 +26,13 @@
 		<param name="android-package"
 			value="org.apache.cordova.networkinformation.NetworkManager" />
 		<param name="ios-package" value="CDVConnection" />
+	</feature>
+	<feature name="Device">
+		<param name="android-package" value="org.apache.cordova.device.Device" />
+		<param name="ios-package" value="CDVDevice" />
+	</feature>
+	<feature name="StatusBar">
+		<param name="ios-package" value="CDVStatusBar" />
 	</feature>
 
 </widget>

--- a/kitchensink-cordova/www/css/screen.css
+++ b/kitchensink-cordova/www/css/screen.css
@@ -153,6 +153,10 @@ span.success {
     background-image: linear-gradient( #EEE, #DDD);
 }
 
+.ui-header {
+	border-top: 1px solid #81B9EF
+}
+
 .app-responsive .ui-block-a,
 .app-responsive .ui-block-b,
 .app-responsive .ui-block-c,

--- a/kitchensink-cordova/www/index.html
+++ b/kitchensink-cordova/www/index.html
@@ -76,6 +76,13 @@
 
 	        //Show device info on member registration page
 	        document.addEventListener("deviceready", function() {
+		        // Detect if iOS 7 or higher and disable overlaying the status bar
+		        if(window.device.platform.toLowerCase() == "ios" &&
+		            parseFloat(window.device.version) >= 7.0) {
+		            StatusBar.overlaysWebView(false);
+		            StatusBar.styleDefault();
+		            StatusBar.backgroundColorByHexString("#81B9EF");
+		        }
 	            updateConnectionType();
 	        });
 


### PR DESCRIPTION
The StatusBar plugin and the Device plugin is used to determine
whether to disable overlaying the statusbar on the app, and what
background color to use for the statusbar.

Also modified the bundle identifier of the Cordova Contacts based
quickstart.
