### PR TITLE
[WFK2-456, JDF-638] - Fix contacts-mobile-basic integration test.

### DIFF
--- a/contacts-mobile-basic/src/test/java/org/jboss/quickstarts/wfk/test/MemberRegistrationTest.java
+++ b/contacts-mobile-basic/src/test/java/org/jboss/quickstarts/wfk/test/MemberRegistrationTest.java
@@ -19,7 +19,7 @@ package org.jboss.quickstarts.wfk.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.sql.Date;
+import java.util.Date;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -39,6 +39,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.jboss.quickstarts.wfk.model.Member;
+import org.jboss.quickstarts.wfk.util.ConvertDate;
 import org.jboss.quickstarts.wfk.util.Resources;
 
 /**
@@ -48,22 +49,24 @@ import org.jboss.quickstarts.wfk.util.Resources;
  */
 @RunWith(Arquillian.class)
 public class MemberRegistrationTest {
+	
     @Deployment
     public static Archive<?> createTestArchive() {
         return ShrinkWrap
             .create(WebArchive.class, "test.war")
             .addClasses(Member.class, MemberService.class, MemberRepository.class, MemberRegistration.class,
-                Resources.class).addAsResource("META-INF/test-persistence.xml", "META-INF/persistence.xml")
+                ConvertDate.class, Resources.class).addAsResource("META-INF/test-persistence.xml", "META-INF/persistence.xml")
             .addAsWebInfResource("arquillian-ds.xml").addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject
     MemberService memberRegistration;
-
+    
     @Inject
     Logger log;
     
-    private Date date = Date.valueOf("1985-10-10");
+    //Set millis 498484800000 from 1985-10-10T12:00:00.000Z
+    private Date date = new Date(498484800000L);
 
     @Test
     @InSequence(1)

--- a/contacts-mobile-basic/src/test/qunit/test/app_tests.js
+++ b/contacts-mobile-basic/src/test/qunit/test/app_tests.js
@@ -84,10 +84,10 @@ test('should be able to fill in the edit form with values', 5, function() {
         '</form>'
     );
     
-	var contacts = {email: "jane.doe@company.com", id: 14, firstName: "Jane", lastName: 'Doe', phoneNumber: "1231231231", birthDate:'1966-01-03'};
+	var contacts = {email: "jane.doe@company.com", id: 14, firstName: "Jane", lastName: 'Doe', phoneNumber: "1231231231", birthDate:'1966-01-03T12:00:00.000Z'};
 	APPMODULE.app.buildContactDetail(contacts);
 	strictEqual($('#contacts-edit-input-firstName').val(), 'Jane', 'Expected to find Jane in the first name field.');
-	strictEqual($('#contacts-edit-input-lastName').val(),  'Doe', 'Expected to find Jane in the last name field.');
+	strictEqual($('#contacts-edit-input-lastName').val(),  'Doe', 'Expected to find Doe in the last name field.');
 	strictEqual($('#contacts-edit-input-tel').val(),       '1231231231', 'Expected to find 1231231231 in the phone number field.');
 	strictEqual($('#contacts-edit-input-email').val(),     'jane.doe@company.com', 'Expected to find jane.doe@company.com in the email field.');
 	strictEqual($('#contacts-edit-input-date').val(),      '1966-01-03', 'Expected to find 1966-01-03 in the birthdate field.');

--- a/contacts-mobile-basic/src/test/qunit/test/validation_tests.js
+++ b/contacts-mobile-basic/src/test/qunit/test/validation_tests.js
@@ -265,7 +265,7 @@ test('should display an error message in the birth date field when the birth dat
 	$('#contacts-add-input-email').val    ('john.doe@abc.com')
 	$('#contacts-add-input-date').val     ('Oct 10, 1990')
 	APPMODULE.validation.addContactsFormValidator.form();
-	strictEqual($('label.error').text(), "Only valid date formats like yyyy/mm/dd or yyyy-mm-dd.", 'The date was set to Oct 10, 1990.');
+	strictEqual($('label.error').text(), "Only valid date formats like yyyy-mm-dd. (hint: There are only 12 months and at most 31 days.)", 'The date was set to Oct 10, 1990.');
 });
 
 
@@ -472,7 +472,7 @@ test('should display an error message in the birth date field when the birth dat
 	$('#contacts-edit-input-email').val    ('john.doe@abc.com')
 	$('#contacts-edit-input-date').val     ('Oct 10, 1990')
 	APPMODULE.validation.editContactsFormValidator.form();
-	strictEqual($('label.error').text(), "Only valid date formats like yyyy/mm/dd or yyyy-mm-dd.", 'The date was set to Oct 10, 1990.');
+	strictEqual($('label.error').text(), "Only valid date formats like yyyy-mm-dd. (hint: There are only 12 months and at most 31 days.)", 'The date was set to Oct 10, 1990.');
 });
 
 //test('', 1, function() {


### PR DESCRIPTION
Add missing reference to ConvertDate class to the ShrinkWrap Resolver WebArchive in the contacts-mobile-basic quickstart. 

Update the Date class from java.sql to java.util to match the code being tested.
