### PR TITLE
JDF-645 Disable zooming on device gestures.

### DIFF
--- a/kitchensink-cordova-contacts/www/index.html
+++ b/kitchensink-cordova-contacts/www/index.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" href="css/screen.css"/>
 
     <!-- Set viewport scaling and zoom features -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
 
 	<script type="text/javascript" src="js/libs/jquery-1.9.1.js"></script>
 	<script type="text/javascript">

--- a/kitchensink-cordova/www/index.html
+++ b/kitchensink-cordova/www/index.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" href="css/screen.css"/>
 
     <!-- Set viewport scaling and zoom features -->
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 
     <script type="text/javascript" src="cordova.js"></script>
 	<script type="text/javascript" src="js/libs/jquery-1.9.1.min.js"></script>


### PR DESCRIPTION
This is to ensure that double-tap on iOS7 or pinch-to-zoom on Android do not work for these Cordova apps.
