### PR TITLE
[WFK2-490] - Update spring-kitchensink-* quickstarts to Spring 4.0.2.

### DIFF
--- a/spring-greeter/functional-tests/pom.xml
+++ b/spring-greeter/functional-tests/pom.xml
@@ -45,7 +45,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-greeter/pom.xml
+++ b/spring-greeter/pom.xml
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
@@ -45,7 +45,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-asyncrequestmapping/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/pom.xml
@@ -48,7 +48,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -124,7 +124,6 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${version.h2db}</version>
-                <scope>test</scope>
             </dependency>
 
             <!-- Add JSON dependency, specified in jboss-deployment-structure.xml -->
@@ -132,19 +131,16 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${version.slf4j}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -293,19 +289,16 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/spring-kitchensink-basic/functional-tests/pom.xml
+++ b/spring-kitchensink-basic/functional-tests/pom.xml
@@ -45,7 +45,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-basic/pom.xml
+++ b/spring-kitchensink-basic/pom.xml
@@ -47,7 +47,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -129,7 +129,6 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${version.h2db}</version>
-                <scope>test</scope>
             </dependency>
 
             <!-- Add JSON dependency, specified in jboss-deployment-structure.xml -->
@@ -137,19 +136,16 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${version.slf4j}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -291,26 +287,23 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
 
         <!-- Add JSON dependency, specified in jboss-deployment-structure.xml -->
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/spring-kitchensink-controlleradvice/functional-tests/pom.xml
+++ b/spring-kitchensink-controlleradvice/functional-tests/pom.xml
@@ -45,7 +45,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-controlleradvice/pom.xml
+++ b/spring-kitchensink-controlleradvice/pom.xml
@@ -48,7 +48,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -124,7 +124,6 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${version.h2db}</version>
-                <scope>test</scope>
             </dependency>
 
             <!-- Add JSON dependency, specified in jboss-deployment-structure.xml -->
@@ -132,19 +131,16 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${version.slf4j}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -293,19 +289,16 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/spring-kitchensink-matrixvariables/functional-tests/pom.xml
+++ b/spring-kitchensink-matrixvariables/functional-tests/pom.xml
@@ -45,7 +45,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-matrixvariables/pom.xml
+++ b/spring-kitchensink-matrixvariables/pom.xml
@@ -48,7 +48,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -124,7 +124,6 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${version.h2db}</version>
-                <scope>test</scope>
             </dependency>
 
             <!-- Add JSON dependency, specified in jboss-deployment-structure.xml -->
@@ -132,19 +131,16 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${version.slf4j}</version>
-                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -293,19 +289,16 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/spring-kitchensink-springmvctest/functional-tests/pom.xml
+++ b/spring-kitchensink-springmvctest/functional-tests/pom.xml
@@ -45,7 +45,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-kitchensink-springmvctest/pom.xml
+++ b/spring-kitchensink-springmvctest/pom.xml
@@ -48,7 +48,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
         <version.jboss.bom.eap>6.2.0.GA</version.jboss.bom.eap>
 
         <!-- maven-compiler-plugin -->
@@ -128,7 +128,6 @@
                 <groupId>com.h2database</groupId>
                 <artifactId>h2</artifactId>
                 <version>${version.h2db}</version>
-                <scope>test</scope>
             </dependency>
 
             <!-- Add JSON dependency, specified in jboss-deployment-structure.xml -->
@@ -136,19 +135,16 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-core-asl</artifactId>
                 <version>${version.jackson}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-simple</artifactId>
                 <version>${version.slf4j}</version>
-                <scope>test</scope>
             </dependency>
 
             <!-- JSON Path for MockMVCTest -->
@@ -310,13 +306,11 @@
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-mapper-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -328,7 +322,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/spring-petclinic/functional-tests/pom.xml
+++ b/spring-petclinic/functional-tests/pom.xml
@@ -45,7 +45,7 @@
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import. The JBoss BOMs specify tested stacks. -->
-        <version.jboss.bom.wfk>2.5.0-build-2</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
 
         <!-- other plugin versions -->
         <version.surefire.plugin>2.10</version.surefire.plugin>

--- a/spring-petclinic/pom.xml
+++ b/spring-petclinic/pom.xml
@@ -39,7 +39,7 @@
 		<jboss.maven.plugin.version>7.4.Final</jboss.maven.plugin.version>
 
 		<!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-		<jboss.bom.wfk.version>2.5.0-build-3</jboss.bom.wfk.version>
+		<jboss.bom.wfk.version>2.5.0-build-5</jboss.bom.wfk.version>
 		<jboss.bom.eap.version>6.2.0.GA</jboss.bom.eap.version>
 
 		<!-- Generic properties -->

--- a/spring-resteasy/pom.xml
+++ b/spring-resteasy/pom.xml
@@ -51,7 +51,7 @@
         
 <!--         AT the moment this app does NOT work with Spring 4, so we are keeping it on Spring 3.2.x. I believe there is
              a bug in the Spring code.  Further testing is needed. -->
-        <version.jboss.bom.wfk>2.5.0-build-3</version.jboss.bom.wfk>
+        <version.jboss.bom.wfk>2.5.0-build-5</version.jboss.bom.wfk>
 
         <!-- Other dependency versions -->
 <!--         <version.org.apache.httpcomponents>4.1.4</version.org.apache.httpcomponents> -->


### PR DESCRIPTION
Update spring-kitchensink-\* quickstarts to Spring 4.0.2.

Remove test scope from json dependencies in spring-kitchensink-\* to fix REST endpoints.
