### PR TITLE
JDF-677 Fix failing QUnit test in JBDS

### DIFF
--- a/kitchensink-html5-mobile/src/test/qunit/test/test.js
+++ b/kitchensink-html5-mobile/src/test/qunit/test/test.js
@@ -101,7 +101,7 @@ asyncTest('Register a member with a duplicate email', function() {
     setTimeout(function() {
         // Execute assertions
         equal(options.data, JSON.stringify(memberData));
-        equal($('form span').get(0).outerHTML, '<span class="invalid">Email taken</span>');
+        equal($('form span').html(), 'Email taken');
         start();
     }, 1000);
 });


### PR DESCRIPTION
Removed use of outerHTML. This now relies on the jQuery .html() API in the test assertion thus ensuring that the test works in JBDS 7 on Fedora/Linux.
