### PR TITLE
JDF-639 Converted the JAX-RS resource classes to SLSBs.

### DIFF
--- a/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/wfk/rest/MemberService.java
+++ b/contacts-mobile-basic/src/main/java/org/jboss/quickstarts/wfk/rest/MemberService.java
@@ -16,20 +16,14 @@
  */
 package org.jboss.quickstarts.wfk.rest;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TimeZone;
 import java.util.logging.Logger;
 
-import javax.ejb.Stateful;
-import javax.enterprise.context.RequestScoped;
+import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.NoResultException;
 import javax.validation.ConstraintViolation;
@@ -44,7 +38,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -59,8 +52,7 @@ import org.jboss.quickstarts.wfk.util.ConvertDate;
  * This class produces a RESTful service to read/write the contents of the members table.
  */
 @Path("/members")
-@RequestScoped
-@Stateful
+@Stateless
 public class MemberService {
     @Inject
     private Logger log;

--- a/kitchensink-backbone/src/main/java/org/jboss/as/quickstarts/kitchensink/rest/MemberService.java
+++ b/kitchensink-backbone/src/main/java/org/jboss/as/quickstarts/kitchensink/rest/MemberService.java
@@ -23,8 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import javax.ejb.Stateful;
-import javax.enterprise.context.RequestScoped;
+import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.NoResultException;
 import javax.validation.ConstraintViolation;
@@ -37,7 +36,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -52,8 +50,7 @@ import org.jboss.as.quickstarts.kitchensink.service.MemberRegistration;
  * members table.
  */
 @Path("/members")
-@RequestScoped
-@Stateful
+@Stateless
 public class MemberService {
     @Inject
     private Logger log;

--- a/kitchensink-html5-mobile/src/main/java/org/jboss/as/quickstarts/html5_mobile/rest/MemberService.java
+++ b/kitchensink-html5-mobile/src/main/java/org/jboss/as/quickstarts/html5_mobile/rest/MemberService.java
@@ -23,8 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import javax.ejb.Stateful;
-import javax.enterprise.context.RequestScoped;
+import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.NoResultException;
 import javax.validation.ConstraintViolation;
@@ -37,7 +36,6 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -51,8 +49,7 @@ import org.jboss.as.quickstarts.html5_mobile.service.MemberRegistration;
  * This class produces a RESTful service to read/write the contents of the members table.
  */
 @Path("/members")
-@RequestScoped
-@Stateful
+@Stateless
 public class MemberService {
     @Inject
     private Logger log;


### PR DESCRIPTION
This now ensures that the root-resource classes now comply with the requirements outlined in JAX-RS 1.1, namely that JAX-RS providers supporting EJBs allow SLSBs as root resource classes
(with no mention of SFSBs).

Since JAX-RS root-resource classes are request-scoped by default, the CDI RequestScoped annotation is redundant and thus removed.

Also removed unused imports.
