### PR TITLE
WFK2-534 Constrain subdirectory search to immediate children.

### DIFF
--- a/dist/release-utils.sh
+++ b/dist/release-utils.sh
@@ -96,7 +96,7 @@ markdown_to_html()
    subdirs=`find . -maxdepth 1 -type d ! -iname ".*" ! -iname "template" | sort`
    for subdir in $subdirs
    do
-      readmes=`find $subdir -iname readme.md`
+      readmes=`find $subdir -maxdepth 1 -iname readme.md`
       for readme in $readmes
       do
          echo "Processing $readme"


### PR DESCRIPTION
This ensures that Cordova plugins containing README.md files are not processed to generate README.html files.

This also fixes issues with other temporary directories like 'bin' or 'target' that may contain READMEs.
