### PR TITLE
GWT Super Dev Mode

### DIFF
--- a/helloworld-gwt/README.md
+++ b/helloworld-gwt/README.md
@@ -83,7 +83,7 @@ Super Dev Mode allows GWT developers to quickly recompile their code and see the
 
 4. Open your browser to <http://localhost:9876/>.
 5. Drag the two bookmarklets "Dev Mode On" and "Dev Mode Off" to your browser's bookmark bar.
-6. Open your browser on <http://localhost:8080/jboss-helloworld-gwt/>.
+6. Open your browser to <http://localhost:8080/jboss-helloworld-gwt/>.
 7. Click "Dev Mode On" to start development mode.
 8. If your browser support Source Maps, you can use it to see the Java source code and set breakpoints using the developer tools directly in the browser.
 

--- a/helloworld-gwt/README.md
+++ b/helloworld-gwt/README.md
@@ -81,9 +81,9 @@ Super Dev Mode allows GWT developers to quickly recompile their code and see the
 
         mvn gwt:run-codeserver
 
-4. Open your browser to <http://localhost:9876/>.
+4. Open this link <http://localhost:9876/> in your browser.
 5. Drag the two bookmarklets "Dev Mode On" and "Dev Mode Off" to your browser's bookmark bar.
-6. Open your browser to <http://localhost:8080/jboss-helloworld-gwt/>.
+6. Navigate your browser to <http://localhost:8080/jboss-helloworld-gwt/>.
 7. Click "Dev Mode On" to start development mode.
 8. If your browser support Source Maps, you can use it to see the Java source code and set breakpoints using the developer tools directly in the browser.
 

--- a/helloworld-gwt/README.md
+++ b/helloworld-gwt/README.md
@@ -70,16 +70,23 @@ Undeploy the Archive
         mvn jboss-as:undeploy
 
 
-Run the Application in GWT Dev Mode
+Run the Application in GWT Super Dev Mode
 ---------------------------------------
 
-GWT Dev Mode provides an edit-save-refresh development experience. If you plan to modify this demo, we recommend you start the application in Dev Mode so you don't have to repackage the entire application every time you change it.
+Super Dev Mode allows GWT developers to quickly recompile their code and see the results in a browser. If you plan to modify this demo, we recommend you start the application in Super Dev Mode so you don't have to repackage the entire application every time you change it. It also allows developers to use a debugger to inspect a running GWT application. 
 
 1. Deploy the WAR file and start the JBoss EAP server as described above.
-2. Open a command line and navigate to the helloworld-gwt quickstart directory
+2. Open a command line and navigate to the helloworld-gwt quickstart directory.
 3. Execute the following command:
 
-        mvn gwt:run
+        mvn gwt:run-codeserver
+
+4. Open your browser to <http://localhost:9876/>.
+5. Drag the two bookmarklets "Dev Mode On" and "Dev Mode Off" to your browser's bookmark bar.
+6. Open your browser on <http://localhost:8080/jboss-helloworld-gwt/>.
+7. Click "Dev Mode On" to start development mode.
+8. If your browser support Source Maps, you can use it to see the Java source code and set breakpoints using the developer tools directly in the browser.
+
 
 Run the Arquillian Functional Tests
 -----------------------------------

--- a/helloworld-gwt/src/main/java/org/jboss/as/quickstarts/gwthelloworld/HelloWorldApp.gwt.xml
+++ b/helloworld-gwt/src/main/java/org/jboss/as/quickstarts/gwthelloworld/HelloWorldApp.gwt.xml
@@ -24,4 +24,11 @@
   <inherits name="com.google.gwt.json.JSON" />
   <entry-point
     class="org.jboss.as.quickstarts.gwthelloworld.client.local.HelloWorldApp" />
+
+    <!-- Allow Super Dev Mode -->
+    <add-linker name="xsiframe" />
+    <set-configuration-property name="devModeRedirectEnabled" value="true" />
+    
+    <!-- Allow Source Maps -->
+    <set-property name="compiler.useSourceMaps" value="true" />
 </module>


### PR DESCRIPTION
According to release notes for GWT 2.6.0 the GWT Developer Mode will no longer be available for Chrome sometime in 2014 [1], I've replaced the description of standard Dev Mode with a description of the new Super Dev Mode [2]. I've also added necessary configuration lines into the .gwt.xml file to enable Super Dev Mode.

[1] http://www.gwtproject.org/release-notes.html#Release_Notes_2_6_0
[2] http://www.gwtproject.org/articles/superdevmode.html
