### PR TITLE
WFK2-705 - replaced deprecated classes in ftests

### DIFF
--- a/contacts-mobile-basic/functional-tests/src/test/java/org/jboss/as/quickstarts/contacts/test/RESTTest.java
+++ b/contacts-mobile-basic/functional-tests/src/test/java/org/jboss/as/quickstarts/contacts/test/RESTTest.java
@@ -16,11 +16,16 @@
  */
 package org.jboss.as.quickstarts.contacts.test;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -33,10 +38,6 @@ import org.json.JSONObject;
 import org.json.JSONStringer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for REST API of the application
@@ -59,7 +60,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/contacts/";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.

--- a/kitchensink-angularjs-bootstrap/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
+++ b/kitchensink-angularjs-bootstrap/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
@@ -16,11 +16,16 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -33,10 +38,6 @@ import org.json.JSONObject;
 import org.json.JSONStringer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for REST API of the application
@@ -54,7 +55,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/members";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.

--- a/kitchensink-angularjs/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
+++ b/kitchensink-angularjs/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
@@ -16,11 +16,16 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -33,10 +38,6 @@ import org.json.JSONObject;
 import org.json.JSONStringer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for REST API of the application
@@ -54,7 +55,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/members";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.

--- a/kitchensink-backbone/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
+++ b/kitchensink-backbone/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
@@ -16,11 +16,16 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -33,10 +38,6 @@ import org.json.JSONObject;
 import org.json.JSONStringer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for REST API of the application
@@ -54,7 +55,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/members";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.

--- a/kitchensink-rf/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkRichFacesTest.java
+++ b/kitchensink-rf/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkRichFacesTest.java
@@ -32,8 +32,8 @@ import org.openqa.selenium.WebElement;
 import java.net.URL;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.jboss.arquillian.graphene.Graphene.waitAjax;
 import static org.jboss.arquillian.graphene.Graphene.waitModel;
 

--- a/kitchensink-rf/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
+++ b/kitchensink-rf/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
@@ -16,11 +16,14 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -33,8 +36,6 @@ import org.json.JSONStringer;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
 
 /**
  * Test for REST API of the application
@@ -51,7 +52,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/members";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.
@@ -89,7 +90,7 @@ public class RESTTest {
     @Test
     @InSequence(2)
     public void testGetMember() throws Exception {
-        DefaultHttpClient httpClient = this.httpClient;
+        CloseableHttpClient httpClient = this.httpClient;
 
         HttpResponse response = httpClient.execute(new HttpGet(contextPath.toString() + API_PATH));
         Assert.assertEquals(200, response.getStatusLine().getStatusCode());

--- a/spring-kitchensink-asyncrequestmapping/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringAsyncRequestMappingTest.java
+++ b/spring-kitchensink-asyncrequestmapping/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringAsyncRequestMappingTest.java
@@ -34,8 +34,8 @@ import org.openqa.selenium.support.FindBy;
 
 import java.net.URL;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Kitchensink Spring AsyncRequestMapping quickstart functional test

--- a/spring-kitchensink-asyncrequestmapping/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
+++ b/spring-kitchensink-asyncrequestmapping/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
@@ -16,9 +16,14 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -28,10 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for REST API of the application
@@ -48,7 +49,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/members";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.

--- a/spring-kitchensink-basic/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringBasicTest.java
+++ b/spring-kitchensink-basic/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringBasicTest.java
@@ -34,8 +34,8 @@ import org.openqa.selenium.support.FindBy;
 
 import java.net.URL;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Kitchensink Spring Basic quickstart functional test

--- a/spring-kitchensink-basic/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
+++ b/spring-kitchensink-basic/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
@@ -16,9 +16,14 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -28,10 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for REST API of the application
@@ -48,7 +49,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/members";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.

--- a/spring-kitchensink-controlleradvice/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringControllerAdviceTest.java
+++ b/spring-kitchensink-controlleradvice/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringControllerAdviceTest.java
@@ -37,8 +37,8 @@ import org.openqa.selenium.support.FindBy;
 import javax.swing.*;
 import java.net.URL;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Kitchensink Spring ControllerAdvice quickstart functional test

--- a/spring-kitchensink-controlleradvice/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
+++ b/spring-kitchensink-controlleradvice/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
@@ -16,9 +16,14 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -28,10 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for REST API of the application
@@ -48,7 +49,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/members";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.

--- a/spring-kitchensink-matrixvariables/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringMatrixVariablesTest.java
+++ b/spring-kitchensink-matrixvariables/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringMatrixVariablesTest.java
@@ -36,7 +36,7 @@ import org.openqa.selenium.support.FindBy;
 
 import java.net.URL;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 /**

--- a/spring-kitchensink-matrixvariables/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
+++ b/spring-kitchensink-matrixvariables/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
@@ -16,9 +16,14 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -28,10 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for REST API of the application
@@ -48,7 +49,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/members";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.

--- a/spring-kitchensink-springmvctest/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringMVCTest.java
+++ b/spring-kitchensink-springmvctest/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/KitchensinkSpringMVCTest.java
@@ -34,7 +34,7 @@ import org.openqa.selenium.support.FindBy;
 
 import java.net.URL;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 /**

--- a/spring-kitchensink-springmvctest/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
+++ b/spring-kitchensink-springmvctest/functional-tests/src/test/java/org/jboss/as/quickstarts/kitchensink/test/RESTTest.java
@@ -16,9 +16,14 @@
  */
 package org.jboss.as.quickstarts.kitchensink.test;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -28,10 +33,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.net.URL;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test for REST API of the application
@@ -48,7 +49,7 @@ public class RESTTest {
 
     private static final String API_PATH = "rest/members";
 
-    private final DefaultHttpClient httpClient = new DefaultHttpClient();
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 
     /**
      * Injects URL on which application is running.


### PR DESCRIPTION
the "junit.framework.Assert" have been replaced with "org.junit.Assert" and the "org.apache.http.impl.client.DefaultHttpClient" with "org.apache.http.impl.client.HttpClientBuilder"
