### PR TITLE
WFK2-772 replaced deprecated method in GWT helloworld quickstart

### DIFF
--- a/helloworld-gwt/src/main/java/org/jboss/as/quickstarts/gwthelloworld/client/local/HelloWorldClient.java
+++ b/helloworld-gwt/src/main/java/org/jboss/as/quickstarts/gwthelloworld/client/local/HelloWorldClient.java
@@ -29,7 +29,6 @@ import com.google.gwt.http.client.URL;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
-import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Panel;
@@ -58,7 +57,7 @@ public class HelloWorldClient {
 
     HelloWorldClient() {
         uiBinder.createAndBindUi(this);
-        DOM.setElementAttribute(sayHelloButton.getElement(), "name", "sayHelloButton");
+        sayHelloButton.getElement().setAttribute("name", "sayHelloButton");
     }
 
     /**


### PR DESCRIPTION
replaced the deprecated method:
setElementAttribute(Element, String, String) from the type DOM
with:
Element.setAttribute(String, String)
