### PR TITLE
WFK2-772 Disabled automatic CDI configuration of the ftest projects

### DIFF
--- a/contacts-mobile-basic/functional-tests/pom.xml
+++ b/contacts-mobile-basic/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/deltaspike-authorization/functional-tests/pom.xml
+++ b/deltaspike-authorization/functional-tests/pom.xml
@@ -39,6 +39,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/deltaspike-beanmanagerprovider/functional-tests/pom.xml
+++ b/deltaspike-beanmanagerprovider/functional-tests/pom.xml
@@ -39,6 +39,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/deltaspike-exception-handling/functional-tests/pom.xml
+++ b/deltaspike-exception-handling/functional-tests/pom.xml
@@ -39,6 +39,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+	    <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/deltaspike-helloworld-jms/functional-tests/pom.xml
+++ b/deltaspike-helloworld-jms/functional-tests/pom.xml
@@ -39,6 +39,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/deltaspike-projectstage/functional-tests/pom.xml
+++ b/deltaspike-projectstage/functional-tests/pom.xml
@@ -39,6 +39,9 @@
         resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/helloworld-gwt/functional-tests/pom.xml
+++ b/helloworld-gwt/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/helloworld-html5/functional-tests/pom.xml
+++ b/helloworld-html5/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/helloworld-rf/functional-tests/pom.xml
+++ b/helloworld-rf/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/kitchensink-angularjs-bootstrap/functional-tests/pom.xml
+++ b/kitchensink-angularjs-bootstrap/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/kitchensink-angularjs/functional-tests/pom.xml
+++ b/kitchensink-angularjs/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/kitchensink-backbone/functional-tests/pom.xml
+++ b/kitchensink-backbone/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/kitchensink-deltaspike/functional-tests/pom.xml
+++ b/kitchensink-deltaspike/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/kitchensink-rf/functional-tests/pom.xml
+++ b/kitchensink-rf/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/richfaces-validation/functional-tests/pom.xml
+++ b/richfaces-validation/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/spring-greeter/functional-tests/pom.xml
+++ b/spring-greeter/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
+++ b/spring-kitchensink-asyncrequestmapping/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/spring-kitchensink-basic/functional-tests/pom.xml
+++ b/spring-kitchensink-basic/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/spring-kitchensink-controlleradvice/functional-tests/pom.xml
+++ b/spring-kitchensink-controlleradvice/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/spring-kitchensink-matrixvariables/functional-tests/pom.xml
+++ b/spring-kitchensink-matrixvariables/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/spring-kitchensink-springmvctest/functional-tests/pom.xml
+++ b/spring-kitchensink-springmvctest/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 

--- a/spring-petclinic/functional-tests/pom.xml
+++ b/spring-petclinic/functional-tests/pom.xml
@@ -40,6 +40,9 @@
                          resources, i.e. build is platform dependent! -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <!-- To disable warning of missing beans.xml file in JBoss Tools -->
+        <m2e.cdi.activation>false</m2e.cdi.activation>
+
         <!-- JBoss dependency versions -->
         <version.jboss.maven.plugin>7.4.Final</version.jboss.maven.plugin>
 


### PR DESCRIPTION
Disabled an automatic CDI configuration of the ftest projects via this pom property:
<m2e.cdi.activation>false</m2e.cdi.activation>
